### PR TITLE
Fixing test, adding parameters to blastn, minor bugfixes

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,6 +1,3 @@
 sample,fastq_1,fastq_2,fastq_3
-test_minigut_hg38host,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_hg38host_R1.fastq.gz,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_hg38host_R2.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz
 test_minigut_forward_reverse_hg38host,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_hg38host_R1.fastq.gz,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_hg38host_R2.fastq.gz,
 test_minigut_forward_hg38host,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_hg38host_R1.fastq.gz,,
-test_minigut_long_hg38host,,,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz
-test_minigut_forward_long_hg38host,https://github.com/nf-core/test-datasets/raw/mag/test_data/test_minigut_sample2_hg38host_R1.fastq.gz,,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz

--- a/assets/samplesheet_benchmarking.csv
+++ b/assets/samplesheet_benchmarking.csv
@@ -1,4 +1,3 @@
 sample,fastq_1,fastq_2,fastq_3
-test_simulated_data,https://zenodo.org/record/8339791/files/metagenome_R1.illumina.fq.gz,https://zenodo.org/record/8339791/files/metagenome_R2.illumina.fq.gz,https://zenodo.org/record/8339789/files/metagenome.ont.fq.gz
-test_human_covid,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_test_1.fastq.gz,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_test_2.fastq.gz,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_long_read_pacbio_nanopore_mix.fastq.gz
-test_human_covid_long,,,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_long_read_pacbio_nanopore_mix.fastq.gz
+test_simulated_data,https://zenodo.org/record/8339791/files/metagenome_R1.illumina.fq.gz,https://zenodo.org/record/8339791/files/metagenome_R2.illumina.fq.gz,
+test_human_covid,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_test_1.fastq.gz,https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/human_covid_test_2.fastq.gz,

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -48,4 +48,3 @@
         "required": ["sample"]
     }
 }
-

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-max_target_seqs ${params.blast_max_target_seqs} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-max_target_seqs ${params.blast_max_target_seqs} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-max_hsps ${params.blast_max_hsps} -max_target_seqs ${params.blast_max_target_seqs} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-max_target_seqs ${params.blast_max_target_seqs} params-max_hsps ${params.blast_max_hsps} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-max_target_seqs ${params.blast_max_target_seqs} -max_hsps ${params.blast_max_hsps} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,7 +18,7 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
         enabled: false
     ]
-    
+
     withName: FASTP {
         ext.args = [
             "-q ${params.fastp_qualified_quality}",
@@ -102,7 +102,7 @@ process {
             enabled: true
         ]
     }
-    
+
     withName: FILTER_BLASTN_IDENTCOV {
         publishDir = [
             path: { "${params.outdir}/blast/filteredIdentCov" },
@@ -121,7 +121,7 @@ process {
         ]
     }
 
-   withName: SUMMARY_KRAKEN2 {
+    withName: SUMMARY_KRAKEN2 {
         publishDir = [
             path: { "${params.outdir}/kraken2/summary" },
             mode: params.publish_dir_mode,
@@ -130,7 +130,7 @@ process {
         ]
     }
 
-   withName: SUMMARIZER {
+    withName: SUMMARIZER {
         publishDir = [
             path: { "${params.outdir}/summary" },
             mode: params.publish_dir_mode,
@@ -138,7 +138,7 @@ process {
             enabled: true
         ]
     }
-    
+
     withName: MULTIQC {
         publishDir = [
             path: { "${params.outdir}/MultiQC" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-max_hsps ${params.blast_max_hsps} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-max_target_seqs ${params.blast_max_target_seqs} params-max_hsps ${params.blast_max_hsps} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-max_hsps ${params.blast_max_hsps} -max_target_seqs ${params.blast_max_target_seqs} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-max_hsps ${params.blast_max_hsps} -evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
     }
 
     withName: BLAST_BLASTN {
-        ext.args = ["-outfmt \"${params.blast_outformat}\""].join(' ').trim()
+        ext.args = ["-evalue ${params.blast_evalue} -outfmt \"${params.blast_outformat}\""].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/blast" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,7 +26,7 @@ params {
 
     // Genome references
     fasta       = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta"
-    
+
     // Kraken2 test db
     kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
     kraken2confidence   = 0.00

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,7 +28,9 @@ params {
     fasta       = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta"
     
     // Kraken2 test db
-    kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
+// TODO: GET PARSE_KRAKEN2REPORT running with minigut_kraken
+//    kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
+    kraken2db           = "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20231009.tar.gz"
     kraken2confidence   = 0.00
     tax2filter          = 'Homo sapiens'
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -33,5 +33,5 @@ params {
     tax2filter          = 'Homo sapiens'
 
     blast_coverage      = 40.0
-    blast_similarity    = 40.0
+    blast_identity    = 40.0
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -30,7 +30,7 @@ params {
     // Kraken2 test db
     kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
     kraken2confidence   = 0.00
-    tax2filter          = 'Homo sapiens'
+    tax2filter          = 'unclassified'
 
     blast_coverage      = 40.0
     blast_identity      = 40.0

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,12 +28,10 @@ params {
     fasta       = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta"
     
     // Kraken2 test db
-// TODO: GET PARSE_KRAKEN2REPORT running with minigut_kraken
-//    kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
-    kraken2db           = "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20231009.tar.gz"
+    kraken2db        = "https://github.com/jannikseidelQBiC/detaxizer/raw/dev/testdata/minigut_kraken.tar.gz"
     kraken2confidence   = 0.00
     tax2filter          = 'Homo sapiens'
 
     blast_coverage      = 40.0
-    blast_identity    = 40.0
+    blast_identity      = 40.0
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -21,7 +21,7 @@ params {
     // Genome references
     fasta         = "s3://ngi-igenomes/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
     // Kraken2 test db
-    kraken2db        = "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20230605.tar.gz"
+    kraken2db           = "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20231009.tar.gz"
     kraken2confidence   = 0.00
     tax2filter          = 'Mammalia'
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -26,5 +26,5 @@ params {
     tax2filter          = 'Mammalia'
 
     blast_coverage      = 40.0
-    blast_similarity    = 40.0
+    blast_identity    = 40.0
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -26,5 +26,5 @@ params {
     tax2filter          = 'Mammalia'
 
     blast_coverage      = 40.0
-    blast_identity    = 40.0
+    blast_identity      = 40.0
 }

--- a/lib/WorkflowDetaxizer.groovy
+++ b/lib/WorkflowDetaxizer.groovy
@@ -15,8 +15,8 @@ class WorkflowDetaxizer {
         genomeExistsError(params, log)
 
 
-        if (!params.fasta) {
-            Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
+        if (!params.fasta && !params.genome) {
+            Nextflow.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file. If no fasta is specified a genome has to be specified, e.g. '--genome GRCh38' "
         }
     }
 

--- a/modules/local/filter_blastn_identcov.nf
+++ b/modules/local/filter_blastn_identcov.nf
@@ -37,5 +37,4 @@ process FILTER_BLASTN_IDENTCOV {
         f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
         f.write(f'    python: {get_version()}\\n')
     """
-
 }

--- a/modules/local/filter_blastn_identcov.nf
+++ b/modules/local/filter_blastn_identcov.nf
@@ -24,7 +24,7 @@ process FILTER_BLASTN_IDENTCOV {
             end = int(parts[7])
             coverage_per_subject = float(parts[12])
             coverage_per_hsp = float(parts[13])
-            if identity >= $params.blast_similarity and coverage_per_subject > $params.blast_coverage and coverage_per_hsp > $params.blast_coverage:
+            if identity >= $params.blast_identity and coverage_per_subject > $params.blast_coverage and coverage_per_hsp > $params.blast_coverage:
                 out.write(f"{query_id}\\t{identity:.2f}\\t{coverage_per_subject:.2f}\\t{coverage_per_hsp:.2f}\\n")
 
     import subprocess

--- a/modules/local/filter_blastn_identcov.nf
+++ b/modules/local/filter_blastn_identcov.nf
@@ -4,11 +4,11 @@ process FILTER_BLASTN_IDENTCOV {
         'https://depot.galaxyproject.org/singularity/python:3.10.4' :
         'biocontainers/python:3.10.4' }"
     input:
-        tuple val(meta), path(blast_output)
+    tuple val(meta), path(blast_output)
 
     output:
-        tuple val(meta), path('*identcov.txt'), emit: classified
-        path "versions.yml", emit: versions
+    tuple val(meta), path('*identcov.txt'), emit: classified
+    path "versions.yml", emit: versions
 
     script:
     """

--- a/modules/local/isolate_ids_from_kraken2_to_blastn.nf
+++ b/modules/local/isolate_ids_from_kraken2_to_blastn.nf
@@ -1,12 +1,17 @@
 process ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN {
 
+    conda "conda-forge::sed=4.7"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
+
     input:
-        tuple val(meta), path(kraken2results), path(tax2filter)
+    tuple val(meta), path(kraken2results), path(tax2filter)
 
 
     output:
-        tuple val(meta), path('*classified.txt'), emit: classified
-        path "versions.yml", emit: versions
+    tuple val(meta), path('*classified.txt'), emit: classified
+    path "versions.yml", emit: versions
 
     script:
     """
@@ -22,9 +27,8 @@ process ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN {
     fi
     done < $tax2filter
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        grep: \$(grep --version | grep -oP 'grep \\(GNU grep\\) \\K\\d+(\\.\\d+)*')
-    END_VERSIONS
+cat <<-END_VERSIONS > versions.yml
+"${task.process}":
+    grep: \$(grep --version  | sed -n 1p  | sed 's/grep (GNU grep) //')
     """
 }

--- a/modules/local/isolate_ids_from_kraken2_to_blastn.nf
+++ b/modules/local/isolate_ids_from_kraken2_to_blastn.nf
@@ -22,9 +22,9 @@ process ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN {
     fi
     done < $tax2filter
 
-cat <<-END_VERSIONS > versions.yml
-"${task.process}":
-    grep: \$(grep --version | grep -oP 'grep \\(GNU grep\\) \\K\\d+(\\.\\d+)*')
-END_VERSIONS
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        grep: \$(grep --version | grep -oP 'grep \\(GNU grep\\) \\K\\d+(\\.\\d+)*')
+    END_VERSIONS
     """
 }

--- a/modules/local/kraken2preparation.nf
+++ b/modules/local/kraken2preparation.nf
@@ -1,7 +1,7 @@
 process KRAKEN2PREPARATION {
-    
+
     input:
-    path db 
+    path db
 
     output:
     path( "database/" ), emit: db
@@ -13,7 +13,7 @@ process KRAKEN2PREPARATION {
     tar -xf "${db}" -C db_tmp
     mkdir database
     mv `find db_tmp/ -name "*.k2d"` database/
-    
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         tar: \$(tar --version | grep -oP 'tar \\(GNU tar\\) \\K\\d+(\\.\\d+)*')

--- a/modules/local/kraken2preparation.nf
+++ b/modules/local/kraken2preparation.nf
@@ -1,5 +1,9 @@
 process KRAKEN2PREPARATION {
 
+    conda "conda-forge::sed=4.7"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'nf-core/ubuntu:20.04' }"
     input:
     path db
 

--- a/modules/local/parse_kraken2report.nf
+++ b/modules/local/parse_kraken2report.nf
@@ -5,11 +5,11 @@ process PARSE_KRAKEN2REPORT {
         'biocontainers/python:3.10.4' }"
 
     input:
-        tuple val(meta), path(kraken2report)
+    tuple val(meta), path(kraken2report)
 
     output:
-        path "versions.yml", emit: versions
-        path "*.txt", emit: txt
+    path "versions.yml", emit: versions
+    path "*.txt", emit: txt
 
     script:
     """

--- a/modules/local/parse_kraken2report.nf
+++ b/modules/local/parse_kraken2report.nf
@@ -122,7 +122,12 @@ kraken_dict = kraken_taxonomy2hierarchy(kraken_list)
 list_kraken = get_all_keys(kraken_dict)
 result = remove_incomplete_taxa(list_kraken)
 result = generate_dict_for_lookup(result)
-result_to_filter = result["$params.tax2filter"] + ["$params.tax2filter"]
+try:
+    result_to_filter = result["$params.tax2filter"] + ["$params.tax2filter"]
+except KeyError:
+    # Handle the error or raise it again
+    raise KeyError("The taxaomic group/taxon you want to check for/filter out is not in the kraken database. Use a database that includes the taxonomic group or taxon or change the tax2filter parameter to something that is in the database.")
+
 result = get_keys_with_ids(kraken_dict)
 result_tax_name_id = []
 for entry in result_to_filter:

--- a/modules/local/parse_kraken2report.nf
+++ b/modules/local/parse_kraken2report.nf
@@ -3,147 +3,147 @@ process PARSE_KRAKEN2REPORT {
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.10.4' :
         'biocontainers/python:3.10.4' }"
-    
+
     input:
         tuple val(meta), path(kraken2report)
-    
+
     output:
         path "versions.yml", emit: versions
         path "*.txt", emit: txt
-    
+
     script:
     """
     #!/usr/bin/env python
-import subprocess
+    import subprocess
 
 
-def read_in_kraken2report(report):
-    kraken_list = []
+    def read_in_kraken2report(report):
+        kraken_list = []
 
-    with open(report, 'r') as f:
-        for line in f:
-            if not line:
-                continue
+        with open(report, 'r') as f:
+            for line in f:
+                if not line:
+                    continue
 
-            line = line.strip('\\n').split('\\t')
-            kraken_list.append(line)
+                line = line.strip('\\n').split('\\t')
+                kraken_list.append(line)
 
-    return kraken_list
-
-
-def kraken_taxonomy2hierarchy(kraken_list):
-    tax_dict = {}
-    stack = []
-
-    for line in kraken_list:
-        level = (len(line[5]) - len(line[5].strip())) / 2
-        node = line[5].strip()
-        id = line[4]
-
-        while len(stack) > level:
-            stack.pop()
-
-        if level == 0 or not stack:
-            tax_dict[node] = {"id": id}
-            stack = [tax_dict[node]]
-        else:
-            current_level = stack[-1]
-            current_level[node] = {"id": id}
-            stack.append(current_level[node])
+        return kraken_list
 
 
-    return tax_dict
+    def kraken_taxonomy2hierarchy(kraken_list):
+        tax_dict = {}
+        stack = []
 
+        for line in kraken_list:
+            level = (len(line[5]) - len(line[5].strip())) / 2
+            node = line[5].strip()
+            id = line[4]
 
-def get_all_keys(nested_dict, parent_key='', sep='\\t'):
-    keys = []
+            while len(stack) > level:
+                stack.pop()
 
-    for k, v in nested_dict.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-
-        if k == 'id':
-            keys.append(parent_key)
-        elif isinstance(v, dict):
-            keys.extend(get_all_keys(v, new_key, sep=sep))
-
-    return keys
-
-
-def remove_incomplete_taxa(list_kraken):
-    # remove the incomplete paths to the leafs, keep all paths that are ending in a leaf
-    list_kraken.sort()
-    to_remove = set()
-
-    for i in range(len(list_kraken) - 1):
-        if list_kraken[i + 1].startswith(list_kraken[i] + ","):
-            to_remove.add(i)
-
-    return [item for idx, item in enumerate(list_kraken) if idx not in to_remove]
-
-
-def generate_dict_for_lookup(removed_list):
-    lookup_dict = {}
-
-    for entry in removed_list:
-        new_list = entry.split('\\t')
-
-        while new_list:
-            new_entry = new_list.pop(0)
-
-            if new_entry in lookup_dict:
-                lookup_dict[new_entry].update(new_list)
+            if level == 0 or not stack:
+                tax_dict[node] = {"id": id}
+                stack = [tax_dict[node]]
             else:
-                lookup_dict[new_entry] = set(new_list)
-
-    for key in lookup_dict:
-        lookup_dict[key] = sorted(list(lookup_dict[key]))
-
-    sorted_keys = sorted(lookup_dict)
-    return {k: lookup_dict[k] for k in sorted_keys}
-
-def get_keys_with_ids(kraken_dict, results=None):
-    if results is None:
-        results = {}
-
-    for k, v in kraken_dict.items():
-        if isinstance(v, dict):
-            if 'id' in v:
-                results[k] = v['id']
-            results.update(get_keys_with_ids(v, results))
-    return results
-
-def get_version():
-    version_output = subprocess.getoutput('python --version')
-    return version_output.split()[1]
+                current_level = stack[-1]
+                current_level[node] = {"id": id}
+                stack.append(current_level[node])
 
 
-kraken_list = read_in_kraken2report('$kraken2report')
-kraken_dict = kraken_taxonomy2hierarchy(kraken_list)
-list_kraken = get_all_keys(kraken_dict)
-result = remove_incomplete_taxa(list_kraken)
-result = generate_dict_for_lookup(result)
-try:
-    result_to_filter = result["$params.tax2filter"] + ["$params.tax2filter"]
-except KeyError:
-    # Handle the error or raise it again
-    raise KeyError("The taxaomic group/taxon you want to check for/filter out is not in the kraken database. Use a database that includes the taxonomic group or taxon or change the tax2filter parameter to something that is in the database.")
+        return tax_dict
 
-result = get_keys_with_ids(kraken_dict)
-result_tax_name_id = []
-for entry in result_to_filter:
-    tax_name = entry
-    tax_id = str(result[tax_name])
-    #tax_name_id = tax_name + " (taxid " + tax_id + ")"
-    result_tax_name_id.append(tax_id)
-    
-with open('taxa_to_filter.txt', "w") as f:
-    for entry in result_tax_name_id:
-        f.write(entry+'\\n')
 
-# Generate the version.yaml for MultiQC
-with open('versions.yml', 'w') as f:
-    f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
-    f.write(f'    python: {get_version()}\\n')
+    def get_all_keys(nested_dict, parent_key='', sep='\\t'):
+        keys = []
+
+        for k, v in nested_dict.items():
+            new_key = f"{parent_key}{sep}{k}" if parent_key else k
+
+            if k == 'id':
+                keys.append(parent_key)
+            elif isinstance(v, dict):
+                keys.extend(get_all_keys(v, new_key, sep=sep))
+
+        return keys
+
+
+    def remove_incomplete_taxa(list_kraken):
+        # remove the incomplete paths to the leafs, keep all paths that are ending in a leaf
+        list_kraken.sort()
+        to_remove = set()
+
+        for i in range(len(list_kraken) - 1):
+            if list_kraken[i + 1].startswith(list_kraken[i] + ","):
+                to_remove.add(i)
+
+        return [item for idx, item in enumerate(list_kraken) if idx not in to_remove]
+
+
+    def generate_dict_for_lookup(removed_list):
+        lookup_dict = {}
+
+        for entry in removed_list:
+            new_list = entry.split('\\t')
+
+            while new_list:
+                new_entry = new_list.pop(0)
+
+                if new_entry in lookup_dict:
+                    lookup_dict[new_entry].update(new_list)
+                else:
+                    lookup_dict[new_entry] = set(new_list)
+
+        for key in lookup_dict:
+            lookup_dict[key] = sorted(list(lookup_dict[key]))
+
+        sorted_keys = sorted(lookup_dict)
+        return {k: lookup_dict[k] for k in sorted_keys}
+
+    def get_keys_with_ids(kraken_dict, results=None):
+        if results is None:
+            results = {}
+
+        for k, v in kraken_dict.items():
+            if isinstance(v, dict):
+                if 'id' in v:
+                    results[k] = v['id']
+                results.update(get_keys_with_ids(v, results))
+        return results
+
+    def get_version():
+        version_output = subprocess.getoutput('python --version')
+        return version_output.split()[1]
+
+
+    kraken_list = read_in_kraken2report('$kraken2report')
+    kraken_dict = kraken_taxonomy2hierarchy(kraken_list)
+    list_kraken = get_all_keys(kraken_dict)
+    result = remove_incomplete_taxa(list_kraken)
+    result = generate_dict_for_lookup(result)
+    try:
+        result_to_filter = result["$params.tax2filter"] + ["$params.tax2filter"]
+    except KeyError:
+        # Handle the error or raise it again
+        raise KeyError("The taxaomic group/taxon you want to check for/filter out is not in the kraken database. Use a database that includes the taxonomic group or taxon or change the tax2filter parameter to something that is in the database.")
+
+    result = get_keys_with_ids(kraken_dict)
+    result_tax_name_id = []
+    for entry in result_to_filter:
+        tax_name = entry
+        tax_id = str(result[tax_name])
+        #tax_name_id = tax_name + " (taxid " + tax_id + ")"
+        result_tax_name_id.append(tax_id)
+
+    with open('taxa_to_filter.txt', "w") as f:
+        for entry in result_tax_name_id:
+            f.write(entry+'\\n')
+
+    # Generate the version.yaml for MultiQC
+    with open('versions.yml', 'w') as f:
+        f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
+        f.write(f'    python: {get_version()}\\n')
 
     """
 }

--- a/modules/local/prepare_fasta4blastn.nf
+++ b/modules/local/prepare_fasta4blastn.nf
@@ -2,7 +2,7 @@ process PREPARE_FASTA4BLASTN {
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/seqtk%3A1.4--he4a0461_1':
-        'biocontainers/seqtk:1.3--ha92aebf_0' }" 
+        'biocontainers/seqtk:1.3--ha92aebf_0' }"
 
     input:
         tuple val(meta), path(trimmedreads), path(kraken2results)
@@ -23,7 +23,7 @@ process PREPARE_FASTA4BLASTN {
     if [ "$meta.single_end" == "true" ]; then
 
         awk -F'\t' '{print \$2}' ${kraken2results} > ids.txt
-        seqtk subseq ${trimmedreads} ids.txt | seqtk seq -A - > ${meta.id}.fasta    
+        seqtk subseq ${trimmedreads} ids.txt | seqtk seq -A - > ${meta.id}.fasta
 
     else
         awk -F'\t' '{print \$2"/1"}' ${kraken2results} > ids_R1.txt

--- a/modules/local/prepare_fasta4blastn.nf
+++ b/modules/local/prepare_fasta4blastn.nf
@@ -1,6 +1,8 @@
 process PREPARE_FASTA4BLASTN {
 
-    container = "https://depot.galaxyproject.org/singularity/seqtk%3A1.4--he4a0461_1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk%3A1.4--he4a0461_1':
+        'biocontainers/seqtk:1.3--ha92aebf_0' }" 
 
     input:
         tuple val(meta), path(trimmedreads), path(kraken2results)

--- a/modules/local/prepare_fasta4blastn.nf
+++ b/modules/local/prepare_fasta4blastn.nf
@@ -5,12 +5,12 @@ process PREPARE_FASTA4BLASTN {
         'biocontainers/seqtk:1.3--ha92aebf_0' }"
 
     input:
-        tuple val(meta), path(trimmedreads), path(kraken2results)
+    tuple val(meta), path(trimmedreads), path(kraken2results)
 
     output:
-        tuple val(meta), path("*.fasta"), emit: fasta
-        tuple val(meta), path("ids*.txt"), emit: ids
-        path("versions.yml"), emit: versions
+    tuple val(meta), path("*.fasta"), emit: fasta
+    tuple val(meta), path("ids*.txt"), emit: ids
+    path("versions.yml"), emit: versions
 
     script:
     """

--- a/modules/local/summarizer.nf
+++ b/modules/local/summarizer.nf
@@ -5,7 +5,6 @@ process SUMMARIZER {
         'biocontainers/pandas:1.5.2' }"
     input:
         path(tosummarize)
-        
 
     output:
         path("summary.tsv"), emit: summary
@@ -27,9 +26,8 @@ process SUMMARIZER {
     for file in files_blastn:
         df_local = pd.read_csv(file, sep="\\t", index_col=0)
         df_blastn = pd.concat([df_blastn,df_local])
-    
+
     df = pd.concat([df_kraken2, df_blastn.reindex(df_kraken2.index)],axis=1)
-    df.to_csv("summary.tsv",sep="\\t")
-        
+    df.to_csv("summary.tsv",sep="\\t")        
     """
 }

--- a/modules/local/summarizer.nf
+++ b/modules/local/summarizer.nf
@@ -28,6 +28,6 @@ process SUMMARIZER {
         df_blastn = pd.concat([df_blastn,df_local])
 
     df = pd.concat([df_kraken2, df_blastn.reindex(df_kraken2.index)],axis=1)
-    df.to_csv("summary.tsv",sep="\\t")        
+    df.to_csv("summary.tsv",sep="\\t")
     """
 }

--- a/modules/local/summary_blastn.nf
+++ b/modules/local/summary_blastn.nf
@@ -5,7 +5,7 @@ process SUMMARY_BLASTN {
         'biocontainers/pandas:1.5.2' }"
     input:
         tuple val(meta), path(blastn_1), path(blastn_2), path(blastn_3), path(filteredblastn_1), path(filteredblastn_2), path(filteredblastn_3)
-        
+
 
     output:
         tuple val(meta), path("*.blastn_summary.tsv"), emit: summary
@@ -47,7 +47,7 @@ process SUMMARY_BLASTN {
                 blastn.sort()
                 filteredblastn.remove("NO")
                 filteredblastn.sort()
-            
+
             for entry in blastn:
                 if "_R1" in entry:
                     blastnsummary_dict["blastn_1"] = entry
@@ -55,7 +55,7 @@ process SUMMARY_BLASTN {
                     blastnsummary_dict["blastn_2"] = entry
                 elif "_R3" in entry:
                     blastnsummary_dict["blastn_3"] = entry
-            
+
             for entry in filteredblastn:
                 if "_R1" in entry:
                     blastnsummary_dict["filteredblastn_1"] = entry
@@ -63,7 +63,7 @@ process SUMMARY_BLASTN {
                     blastnsummary_dict["filteredblastn_2"] = entry
                 elif "_R3" in entry:
                     blastnsummary_dict["filteredblastn_3"] = entry
-            
+
             summary_keys = blastnsummary_dict.keys()
             if "blastn_1" not in summary_keys and "filteredblastn_1" not in summary_keys:
                 blastnsummary_dict["blastn_1"] = "NA"
@@ -106,7 +106,7 @@ process SUMMARY_BLASTN {
         else:
             lines_blastn += get_lines_in_file(blastnsummary_dict[key])
             unique_ids_blastn.update(get_unique_read_ids(blastnsummary_dict[key]))
-    
+
     final_summary_blastnfilteredblastn = {}
     if counter_NA == 6:
         final_summary_blastnfilteredblastn["blastn_unique_ids"] = pd.NA
@@ -124,6 +124,4 @@ process SUMMARY_BLASTN {
     df.to_csv("${meta.id}.blastn_summary.tsv", sep="\\t")
 
     """
-    
-    
 }

--- a/modules/local/summary_blastn.nf
+++ b/modules/local/summary_blastn.nf
@@ -4,17 +4,18 @@ process SUMMARY_BLASTN {
         'https://depot.galaxyproject.org/singularity/pandas:1.5.2' :
         'biocontainers/pandas:1.5.2' }"
     input:
-        tuple val(meta), path(blastn_1), path(blastn_2), path(blastn_3), path(filteredblastn_1), path(filteredblastn_2), path(filteredblastn_3)
+    tuple val(meta), path(blastn_1), path(blastn_2), path(blastn_3), path(filteredblastn_1), path(filteredblastn_2), path(filteredblastn_3)
 
 
     output:
-        tuple val(meta), path("*.blastn_summary.tsv"), emit: summary
-        //path("versions.yml"), emit: versions
+    tuple val(meta), path("*.blastn_summary.tsv"), emit: summary
+    path("versions.yml"), emit: versions
 
     script:
     """
     #!/usr/bin/env python
     import pandas as pd
+    import subprocess
 
     def get_lines_in_file(filename):
         line_counter = 0
@@ -123,5 +124,13 @@ process SUMMARY_BLASTN {
 
     df.to_csv("${meta.id}.blastn_summary.tsv", sep="\\t")
 
+    def get_version():
+        version_output = subprocess.getoutput('python --version')
+        return version_output.split()[1]
+
+    # Generate the version.yaml for MultiQC
+    with open('versions.yml', 'w') as f:
+        f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
+        f.write(f'    python: {get_version()}\\n')
     """
 }

--- a/modules/local/summary_kraken2.nf
+++ b/modules/local/summary_kraken2.nf
@@ -4,17 +4,17 @@ process SUMMARY_KRAKEN2 {
         'https://depot.galaxyproject.org/singularity/pandas:1.5.2' :
         'biocontainers/pandas:1.5.2' }"
     input:
-        tuple val(meta),path(kraken2)
+    tuple val(meta),path(kraken2)
 
 
     output:
-        tuple val(meta), path("*.kraken2_summary.tsv"), emit: summary
-        //path("versions.yml"), emit: versions
+    tuple val(meta), path("*.kraken2_summary.tsv"), emit: summary
+    path("versions.yml"), emit: versions
 
     script:
     """
     #!/usr/bin/env python
-
+    import subprocess
     import pandas as pd
 
     def sort_list_of_files_by_pattern(kraken2_complete_list):
@@ -72,5 +72,14 @@ process SUMMARY_KRAKEN2 {
         df.index = ["${meta.id}"]
 
         df.to_csv("${meta.id}.kraken2_summary.tsv",sep='\\t')
+
+    def get_version():
+        version_output = subprocess.getoutput('python --version')
+        return version_output.split()[1]
+
+    # Generate the version.yaml for MultiQC
+    with open('versions.yml', 'w') as f:
+        f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
+        f.write(f'    python: {get_version()}\\n')
     """
 }

--- a/modules/local/summary_kraken2.nf
+++ b/modules/local/summary_kraken2.nf
@@ -5,7 +5,7 @@ process SUMMARY_KRAKEN2 {
         'biocontainers/pandas:1.5.2' }"
     input:
         tuple val(meta),path(kraken2)
-        
+
 
     output:
         tuple val(meta), path("*.kraken2_summary.tsv"), emit: summary
@@ -27,7 +27,7 @@ process SUMMARY_KRAKEN2 {
                 kraken2_dict["kraken2"].append(entry)
             else:
                 kraken2_dict["isolatedkraken2"].append(entry)
-        
+
         return kraken2_dict
 
     def calculate_lines_of_file(path):
@@ -56,7 +56,6 @@ process SUMMARY_KRAKEN2 {
         df.index = ["${meta.id}"]
 
         df.to_csv("${meta.id}.kraken2_summary.tsv",sep='\\t')
-  
     else:
         list_files = "${kraken2}".split(" ")
         kraken2_dict = sort_list_of_files_by_pattern(list_files)

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,8 +49,9 @@ params {
     // BLASTN parameters
     blastn_db                  = ''
     blast_coverage             = 90.0
-    blast_similarity           = 90.0
+    blast_identity             = 90.0
     blast_outformat            = '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp'
+    blast_evalue               = 0.1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ params {
     fastp_cut_mean_quality               = 15
     save_clipped_reads                   = false
 
-    // Taxon to check for/to filter in kraken2 format <taxid XYZ>
+    // Taxon to check for/to filter in kraken2 format, it has to be in the used kraken2 database
     tax2filter                           = 'Mammalia'
 
     // Kraken2preparation parameter
@@ -52,7 +52,6 @@ params {
     blast_identity             = 90.0
     blast_outformat            = '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp'
     blast_evalue               = 0.01
-    blast_max_target_seqs      = 1
     blast_max_hsps             = 1
 
     // MultiQC options

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ params {
     fastp_cut_mean_quality               = 15
     save_clipped_reads                   = false
 
-    // Taxon to check for/to filter in kraken2 format, it has to be in the used kraken2 database
+    // Taxon to check for/to filter in kraken2 format, it has to be present in the supplied kraken2 database
     tax2filter                           = 'Mammalia'
 
     // Kraken2preparation parameter

--- a/nextflow.config
+++ b/nextflow.config
@@ -53,6 +53,7 @@ params {
     blast_outformat            = '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp'
     blast_evalue               = 0.01
     blast_max_target_seqs      = 1
+    blast_max_hsps             = 1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -53,6 +53,7 @@ params {
     blast_outformat            = '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp'
     blast_evalue               = 0.01
     blast_max_hsps             = 1
+    blast_max_target_seqs      = 1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,8 +17,8 @@ params {
     igenomes_base              = 's3://ngi-igenomes/igenomes'
     igenomes_ignore            = false
     saveReference              = true
-    fasta                      = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
-   
+    fasta                      = false
+    
     // Workflow parameters
     single_end = false
     long_read = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,7 +51,8 @@ params {
     blast_coverage             = 90.0
     blast_identity             = 90.0
     blast_outformat            = '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp'
-    blast_evalue               = 0.1
+    blast_evalue               = 0.01
+    blast_max_target_seqs      = 1
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -16,7 +16,7 @@
                 },
                 "blast_coverage": {
                     "type": "number",
-                    "default": 90.0
+                    "default": 90
                 },
                 "blast_outformat": {
                     "type": "string",
@@ -28,7 +28,7 @@
                 },
                 "blast_identity": {
                     "type": "number",
-                    "default": 90.0
+                    "default": 90
                 },
                 "blast_max_hsps": {
                     "type": "integer",
@@ -183,7 +183,6 @@
                     "format": "file-path",
                     "exists": true,
                     "mimetype": "text/plain",
-                    "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
                     "description": "Path to FASTA genome file.",
                     "help_text": "This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.",
                     "fa_icon": "far fa-file-code"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -18,13 +18,17 @@
                     "type": "number",
                     "default": 90
                 },
-                "blast_similarity": {
-                    "type": "number",
-                    "default": 90
-                },
                 "blast_outformat": {
                     "type": "string",
                     "default": "6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qcovs qcovhsp"
+                },
+                "blast_evalue": {
+                    "type": "number",
+                    "default": 0.1
+                },
+                "blast_identity": {
+                    "type": "number",
+                    "default": 90
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -29,6 +29,10 @@
                 "blast_identity": {
                     "type": "number",
                     "default": 90
+                },
+                "blast_max_target_seqs": {
+                    "type": "integer",
+                    "default": 1
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -33,6 +33,10 @@
                 "blast_max_hsps": {
                     "type": "integer",
                     "default": 1
+                },
+                "blast_max_target_seqs": {
+                    "type": "integer",
+                    "default": 1
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -33,6 +33,10 @@
                 "blast_max_target_seqs": {
                     "type": "integer",
                     "default": 1
+                },
+                "blast_max_hsps": {
+                    "type": "integer",
+                    "default": 1
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -16,7 +16,7 @@
                 },
                 "blast_coverage": {
                     "type": "number",
-                    "default": 90
+                    "default": 90.0
                 },
                 "blast_outformat": {
                     "type": "string",
@@ -28,11 +28,7 @@
                 },
                 "blast_identity": {
                     "type": "number",
-                    "default": 90
-                },
-                "blast_max_target_seqs": {
-                    "type": "integer",
-                    "default": 1
+                    "default": 90.0
                 },
                 "blast_max_hsps": {
                     "type": "integer",

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -73,6 +73,18 @@ include { BLAST_MAKEBLASTDB } from '../modules/nf-core/blast/makeblastdb'
 // Info required for completion email and summary
 def multiqc_report = []
 
+// speficy the fasta parameter if it is not provided via --fasta 
+def fasta = false
+
+if (!params.fasta) {
+    // If params.fasta is false and params.genome is present
+    if (params.genome) {
+        fasta = params.genomes[params.genome]?.fasta ?: false
+    }
+} else {
+    // If params.fasta is there, use it
+    fasta = params.fasta
+}
 
 
 
@@ -271,7 +283,7 @@ workflow DETAXIZER {
     ch_reference_fasta = Channel.empty()
     
     if (!params.skip_blastn) {  // If skip_blastn is false, then execute the process
-        ch_reference_fasta =  file( params.fasta )
+        ch_reference_fasta =  file( fasta )
     }
     
     BLAST_MAKEBLASTDB (

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -180,7 +180,7 @@ workflow DETAXIZER {
         params.fastp_save_trimmed_fail,
         []
     )
-    ch_versions = ch_versions.mix(FASTP.out.versions)
+    ch_versions = ch_versions.mix(FASTP.out.versions.first())
 
     //
     // MODULE: Prepare Kraken2 Database
@@ -201,7 +201,7 @@ workflow DETAXIZER {
         params.save_output_fastqs,
         params.save_reads_assignment
     )
-    ch_versions = ch_versions.mix(KRAKEN2_KRAKEN2.out.versions)
+    ch_versions = ch_versions.mix(KRAKEN2_KRAKEN2.out.versions.first())
 
     //
     // MODULE: Parse the taxonomy from the kraken2 report and return all subclasses of the tax2filter
@@ -222,7 +222,7 @@ workflow DETAXIZER {
         ch_combined
     )
 
-    ch_versions = ch_versions.mix(ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN.out.versions)
+    ch_versions = ch_versions.mix(ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN.out.versions.first())
 
     //
     // MODULE: Summarize the kraken2 results and the isolated kraken2 hits
@@ -259,7 +259,12 @@ workflow DETAXIZER {
     // run of the process
     ch_kraken2_summary = SUMMARY_KRAKEN2(
         ch_combined_kraken2
-        ).map {
+        )
+
+    // Get Software version and prepare it for multiqc
+    ch_versions = ch_versions.mix(ch_kraken2_summary.versions.first())
+
+    ch_kraken2_summary = ch_kraken2_summary.summary.map {
             meta, path -> [path]
         }
     //
@@ -274,7 +279,7 @@ workflow DETAXIZER {
     PREPARE_FASTA4BLASTN (
         ch_combined
     )
-    ch_versions = ch_versions.mix(PREPARE_FASTA4BLASTN.out.versions)    
+    ch_versions = ch_versions.mix(PREPARE_FASTA4BLASTN.out.versions.first())    
 
     // 
     // MODULE: Run BLASTN if --skip_blastn = false
@@ -314,7 +319,7 @@ workflow DETAXIZER {
         BLAST_MAKEBLASTDB.out.db
     )
     
-    ch_versions = ch_versions.mix(BLAST_BLASTN.out.versions)
+    ch_versions = ch_versions.mix(BLAST_BLASTN.out.versions.first())
     
     ch_combined_blast = BLAST_BLASTN.out.txt
                                 .map { meta, path -> 
@@ -329,7 +334,7 @@ workflow DETAXIZER {
     FILTER_BLASTN_IDENTCOV (
         BLAST_BLASTN.out.txt
     )
-    ch_versions = ch_versions.mix(FILTER_BLASTN_IDENTCOV.out.versions)
+    ch_versions = ch_versions.mix(FILTER_BLASTN_IDENTCOV.out.versions.first())
     
     ch_filtered_combined = FILTER_BLASTN_IDENTCOV.out.classified.map { 
         meta, path -> 
@@ -368,23 +373,26 @@ workflow DETAXIZER {
             return [meta, blastn[0], blastn[1], blastn[2], filteredblastn[0], filteredblastn[1], filteredblastn[2]]
         }
 
-    // TODO: Get Software version and prepare it for multiqc
+    // Get Software version and prepare it for multiqc
     ch_blastn_summary = SUMMARY_BLASTN (
         ch_blastn_combined
     )
+    ch_versions = ch_versions.mix(ch_blastn_summary.versions.first())
 
+    ch_blastn_summary = ch_blastn_summary.summary.map {
+            meta, path -> [path]
+        }
     //
     // MODULE: Summarize the classification process
     //
 
     //ch_kraken2_summary = ch_kraken2_summary.map { meta, paths -> [paths] }
-    ch_blastn_summary = ch_blastn_summary.map { meta, paths -> [paths]}
-
     ch_summary = ch_kraken2_summary.mix(ch_blastn_summary).collect()
 
-    SUMMARIZER (
+    ch_summary = SUMMARIZER (
         ch_summary
     )
+    ch_versions = ch_versions.mix(ch_summary.versions)
 
     
 


### PR DESCRIPTION
# Blastn parameters
To reduce the size of output files from blastn `evalue, max_target_seqs and max_hsps` were introduced as parameters. 

# test.conf
To avoid failing the minimal test because of the `tax2filter` (taxon to filter, at the moment only checking if the taxon is in the data) not being in the used minigut kraken2 db it was changed to "unclassified".

# test_full.conf
To make a reasonable test only the 8 GB Standard kraken2 is now used instead of Standard (approx. 60 GB).

# fasta parameter for the creation of blastn db
To avoid failure of the pipeline because of an empty `fasta` parameter (which should be taken from the `igenome.conf` in this case) it was moved to the `workflow/detaxizer.nf`.

# Samplesheets
The `samplesheet.csv` for the minimal test was reduced so that a small test can be run by github
The benchmarking samplesheet was expanded with testdata for a mix of human and Covid19 data.
The long reads were excluded for now and will be added later on.

# `modules/local/parse_kraken2report.nf` 
The pipeline now fails gracefully if the `tax2filter` is not in the kraken2 DB and shows an explanatory error message.

# `prepare_fasta4blastn.nf` now supports docker
Docker support was added to make tests possible.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/detaxizer _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
