### PR TITLE
Restructuring of the renaming steps plus gzipping of jsons in the renaming step

### DIFF
--- a/bin/rename_fastq_headers_after.py
+++ b/bin/rename_fastq_headers_after.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+from Bio import SeqIO, bgzf
+import gzip
+import sys
+import json
+import argparse
+
+def parse_args(args=None):
+
+    parser = argparse.ArgumentParser(description="Renaming of the headers after running the core processes of the detaxizer pipeline.")
+
+    parser.add_argument("-i", "--input", help="Path to input files.", type=str, required=True, nargs="+")
+
+    parser.add_argument("-j", "--jsondict", help="Path to the gzipped json containing the IDs of the headers and the original headers.", type=str, required=True)
+
+    parser.add_argument("-o", "--output", help="Prefix of output files.", type=str, required=True)
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    fastq = args.input
+
+    with gzip.open(args.jsondict, 'r') as file:
+        headerDict = json.load(file)
+
+    if len(fastq) == 2:
+        with gzip.open(fastq[0], "rt") as handle1, gzip.open(fastq[1], "rt") as handle2:
+            with bgzf.BgzfWriter(args.output + "_R1_filtered.fastq.gz", "wb") as outgz1, bgzf.BgzfWriter(args.output + "_R2_filtered.fastq.gz", "wb") as outgz2:
+                for i,j in zip(SeqIO.parse(handle1, "fastq"),SeqIO.parse(handle2, "fastq")):
+                    id_fw = i.id
+                    id_rv = j.id
+                    if id_fw != id_rv:
+                        sys.exit("The IDs did not match. The provided fastq files are either not sorted or a sequence is missing.")
+                    lookupHeaders = headerDict[id_fw]
+                    i.id = lookupHeaders[0]
+                    i.description = ""
+                    j.id = lookupHeaders[1]
+                    j.description = ""
+                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
+                    SeqIO.write(sequences=j, handle=outgz2, format="fastq")
+    else:
+        with gzip.open(fastq[0], "rt") as handle1:
+            with bgzf.BgzfWriter(args.output + "_filtered.fastq.gz", "wb") as outgz1:
+                for i in SeqIO.parse(handle1, "fastq"):
+                    id_fw = i.id
+                    lookupHeaders = headerDict[id_fw]
+                    i.id = lookupHeaders[0]
+                    i.description = ""
+                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/rename_fastq_headers_after.py
+++ b/bin/rename_fastq_headers_after.py
@@ -22,8 +22,9 @@ def main():
 
     fastq = args.input
 
-    with gzip.open(args.jsondict, 'r') as file:
-        headerDict = json.load(file)
+    with gzip.open(args.jsondict, 'rt', encoding='utf-8') as file:
+        textDict = file.read()
+        headerDict = json.loads(textDict)
 
     if len(fastq) == 2:
         with gzip.open(fastq[0], "rt") as handle1, gzip.open(fastq[1], "rt") as handle2:

--- a/bin/rename_fastq_headers_after.py
+++ b/bin/rename_fastq_headers_after.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+# Written by Jannik Seidel and released under MIT license.
+
 from Bio import SeqIO, bgzf
 import gzip
 import sys

--- a/bin/rename_fastq_headers_pre.py
+++ b/bin/rename_fastq_headers_pre.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+# Written by Jannik Seidel and released under MIT license.
+
 from Bio import SeqIO, bgzf
 import gzip
 import sys

--- a/bin/rename_fastq_headers_pre.py
+++ b/bin/rename_fastq_headers_pre.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+from Bio import SeqIO, bgzf
+import gzip
+import sys
+import json
+import argparse
+
+def parse_args(args=None):
+
+    parser = argparse.ArgumentParser(description="Renaming of the headers before running the core processes of the detaxizer pipeline.")
+
+    parser.add_argument("-i", "--input", help="Path to input files.", type=str, required=True, nargs="+")
+
+    parser.add_argument("-o", "--output", help="Prefix of output files.", type=str, required=True)
+
+    return parser.parse_args()
+
+def renameReadsPaired(reads):
+    read_fw = reads[0]
+    read_rv = reads[1]
+    read_dict = {}
+    if "/1" in read_fw and "/2" in read_rv and " " not in read_fw and " " not in read_rv:
+        read_fw_stripped = read_fw.strip("1").strip("/")
+        read_rv_stripped = read_rv.strip("2").strip("/")
+        if read_fw_stripped != read_rv_stripped:
+            sys.exit("Read IDs were not matching! Please provide matching headers.")
+        else:
+            read_dict[read_fw_stripped] = [read_fw, read_rv]
+            read_fw_stripped = read_fw_stripped + " 1:N:10:"
+            read_rv_stripped = read_rv_stripped + " 2:N:10:"
+            read_renamed = [read_fw_stripped,read_rv_stripped]
+    elif "/1" in read_fw and "/2" in read_rv and " " in read_fw and " " in read_rv:
+        read_fw_stripped = read_fw.strip("1").strip("/").split(" ")[0]
+        read_rv_stripped = read_rv.strip("2").strip("/").split(" ")[0]
+        if read_fw_stripped != read_rv_stripped:
+            sys.exit("Read IDs were not matching! Please provide matching headers.")
+        else:
+            read_dict[read_fw_stripped] = [read_fw, read_rv]
+            read_fw_stripped = read_fw_stripped + " 1:N:10:"
+            read_rv_stripped = read_rv_stripped + " 2:N:10:"
+            read_renamed = [read_fw_stripped,read_rv_stripped]
+    elif " 1:" in read_fw and " 2:" in read_rv:
+        read_fw_stripped = read_fw.split(" ")[0]
+        read_rv_stripped = read_rv.split(" ")[0]
+        if read_fw_stripped != read_rv_stripped:
+            sys.exit("Read IDs were not matching! Please provide matching headers.")
+        else:
+            read_dict[read_fw_stripped] = [read_fw, read_rv]
+            read_fw_stripped = read_fw_stripped + " 1:N:10:"
+            read_rv_stripped = read_rv_stripped + " 2:N:10:"
+            read_renamed = [read_fw_stripped,read_rv_stripped]
+    else:
+        sys.exit("The headers were not matching the patterns!")
+    return (read_dict,read_renamed)
+
+def renameReadSingle(read):
+    read_dict = {}
+    if "/1" in read and " " not in read:
+        read_fw_stripped = read.strip("1").strip("/")
+        read_dict[read_fw_stripped] = [read]
+        read_fw_stripped = read_fw_stripped + " 1:N:10:"
+        read_renamed = [read_fw_stripped]
+    elif "/1" in read and " " in read:
+        read_fw_stripped = read.strip("1").strip("/").split(" ")[0]
+        read_dict[read_fw_stripped] = [read]
+        read_fw_stripped = read_fw_stripped + " 1:N:10:"
+        read_renamed = [read_fw_stripped]
+    elif " 1:" in read:
+        read_fw_stripped = read.split(" ")[0]
+        read_dict[read_fw_stripped] = [read]
+        read_fw_stripped = read_fw_stripped + " 1:N:10:"
+        read_renamed = [read_fw_stripped]
+    elif " " in read:
+        read_fw_stripped = read.split(" ")[0]
+        read_dict[read_fw_stripped] = [read]
+        read_fw_stripped = read_fw_stripped + " 1:N:10:"
+        read_renamed = [read_fw_stripped]
+    else:
+        sys.exit("The headers were not matching the patterns!")
+    return (read_dict,read_renamed)
+
+def main():
+    args = parse_args()
+
+    fastq = args.input
+
+    if len(fastq) == 2:
+        renamed = {}
+        with gzip.open(fastq[0], "rt") as handle1, gzip.open(fastq[1], "rt") as handle2:
+            with bgzf.BgzfWriter(args.output + "_R1_renamed.fastq.gz", "wb") as outgz1, bgzf.BgzfWriter(args.output + "_R2_renamed.fastq.gz", "wb") as outgz2:
+                for i,j in zip(SeqIO.parse(handle1, "fastq"),SeqIO.parse(handle2, "fastq")):
+                    header_fw = i.description
+                    header_rv = j.description
+                    headers = (header_fw,header_rv)
+                    headers = renameReadsPaired(headers)
+                    renamed.update(headers[0])
+                    i.description = headers[1][0]
+                    i.id = headers[1][0].split(" ")[0]
+                    j.description = headers[1][1]
+                    j.id = headers[1][1].split(" ")[0]
+                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
+                    SeqIO.write(sequences=j, handle=outgz2, format="fastq")
+        with gzip.open(args.output + "_headers.json.gz", "wt", encoding="utf-8") as outfile:
+            json.dump(renamed, outfile)
+    else:
+        renamed = {}
+        with gzip.open(fastq[0], "rt") as handle1:
+            with bgzf.BgzfWriter(args.output + "_renamed.fastq.gz", "wb") as outgz1:
+                for i in SeqIO.parse(handle1, "fastq"):
+                    header_fw = i.description
+                    headers = renameReadSingle(header_fw)
+                    renamed.update(headers[0])
+                    i.description = headers[1][0]
+                    i.id = headers[1][0].split(" ")[0]
+                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
+        with gzip.open(args.output + "_headers.json.gz", "wt", encoding="utf-8") as outfile:
+            json.dump(renamed, outfile)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/local/rename_fastq_headers_after.nf
+++ b/modules/local/rename_fastq_headers_after.nf
@@ -2,7 +2,7 @@ process RENAME_FASTQ_HEADERS_AFTER {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "conda-forge::python=3.10.4 biopython=1.83 numpy=1.26.3"
+    conda "conda-forge::python=3.12.0 biopython=1.81 numpy=1.26.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/biopython:1.81' :
         'biocontainers/biopython:1.81' }"
@@ -19,52 +19,12 @@ process RENAME_FASTQ_HEADERS_AFTER {
 
     script:
     """
-    #!/usr/bin/env python
-    import Bio
-    from Bio import SeqIO, bgzf
-    import gzip
-    import sys
-    import json
-    import subprocess
+    rename_fastq_headers_after.py -i $fastqfiltered -j $dict -o $meta.id
 
-    def get_version():
-        version_output = subprocess.getoutput('python --version')
-        version = version_output.split()[1]
-        return version
-
-    with open("${dict}", 'r') as file:
-        headerDict = json.load(file)
-
-    fastq = "${fastqfiltered}".split(" ")
-    if len(fastq) == 2:
-        with gzip.open(fastq[0], "rt") as handle1, gzip.open(fastq[1], "rt") as handle2:
-            with bgzf.BgzfWriter("${meta.id}_R1_filtered.fastq.gz", "wb") as outgz1, bgzf.BgzfWriter("${meta.id}_R2_filtered.fastq.gz", "wb") as outgz2:
-                for i,j in zip(SeqIO.parse(handle1, "fastq"),SeqIO.parse(handle2, "fastq")):
-                    id_fw = i.id
-                    id_rv = j.id
-                    if id_fw != id_rv:
-                        sys.exit("The IDs did not match. The provided fastq files are either not sorted or a sequence is missing.")
-                    lookupHeaders = headerDict[id_fw]
-                    i.id = lookupHeaders[0]
-                    i.description = ""
-                    j.id = lookupHeaders[1]
-                    j.description = ""
-                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
-                    SeqIO.write(sequences=j, handle=outgz2, format="fastq")
-
-    else:
-        with gzip.open(fastq[0], "rt") as handle1:
-            with bgzf.BgzfWriter("${meta.id}_filtered.fastq.gz", "wb") as outgz1:
-                for i in SeqIO.parse(handle1, "fastq"):
-                    id_fw = i.id
-                    lookupHeaders = headerDict[id_fw]
-                    i.id = lookupHeaders[0]
-                    i.description = ""
-                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
-
-    with open('versions.yml', 'w') as f:
-        f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
-        f.write(f'    python: {get_version()}\\n')
-        f.write(f'    biopython: {Bio.__version__}\\n')
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+        biopython: \$(python -c "import pkg_resources; print(pkg_resources.get_distribution('biopython').version)")
+    END_VERSIONS
     """
 }

--- a/modules/local/rename_fastq_headers_pre.nf
+++ b/modules/local/rename_fastq_headers_pre.nf
@@ -2,7 +2,7 @@ process RENAME_FASTQ_HEADERS_PRE {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "conda-forge::python=3.10.4 biopython=1.83 numpy=1.26.3"
+    conda "conda-forge::python=3.12.0 biopython=1.81 numpy=1.26.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/biopython:1.81' :
         'biocontainers/biopython:1.81' }"
@@ -11,128 +11,21 @@ process RENAME_FASTQ_HEADERS_PRE {
     tuple val(meta), path(inputfastq)
 
     output:
-    tuple val(meta), path('*_headers.json') , emit: headers
-    tuple val(meta), path('*.fastq.gz')     , emit: fastq
-    path "versions.yml"                     , emit: versions
+    tuple val(meta), path('*_headers.json.gz')  , emit: headers
+    tuple val(meta), path('*.fastq.gz')         , emit: fastq
+    path "versions.yml"                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     """
-    #!/usr/bin/env python
-    import Bio
-    from Bio import SeqIO, bgzf
-    import gzip
-    import sys
-    import json
-    import subprocess
+    rename_fastq_headers_pre.py -i $inputfastq -o $meta.id
 
-    def renameReadsPaired(reads):
-        read_fw = reads[0]
-        read_rv = reads[1]
-        read_dict = {}
-        if "/1" in read_fw and "/2" in read_rv and " " not in read_fw and " " not in read_rv:
-            read_fw_stripped = read_fw.strip("1").strip("/")
-            read_rv_stripped = read_rv.strip("2").strip("/")
-            if read_fw_stripped != read_rv_stripped:
-                sys.exit("Read IDs were not matching! Please provide matching headers.")
-            else:
-                read_dict[read_fw_stripped] = [read_fw, read_rv]
-                read_fw_stripped = read_fw_stripped + " 1:N:10:"
-                read_rv_stripped = read_rv_stripped + " 2:N:10:"
-                read_renamed = [read_fw_stripped,read_rv_stripped]
-        elif "/1" in read_fw and "/2" in read_rv and " " in read_fw and " " in read_rv:
-            read_fw_stripped = read_fw.strip("1").strip("/").split(" ")[0]
-            read_rv_stripped = read_rv.strip("2").strip("/").split(" ")[0]
-            if read_fw_stripped != read_rv_stripped:
-                sys.exit("Read IDs were not matching! Please provide matching headers.")
-            else:
-                read_dict[read_fw_stripped] = [read_fw, read_rv]
-                read_fw_stripped = read_fw_stripped + " 1:N:10:"
-                read_rv_stripped = read_rv_stripped + " 2:N:10:"
-                read_renamed = [read_fw_stripped,read_rv_stripped]
-        elif " 1:" in read_fw and " 2:" in read_rv:
-            read_fw_stripped = read_fw.split(" ")[0]
-            read_rv_stripped = read_rv.split(" ")[0]
-            if read_fw_stripped != read_rv_stripped:
-                sys.exit("Read IDs were not matching! Please provide matching headers.")
-            else:
-                read_dict[read_fw_stripped] = [read_fw, read_rv]
-                read_fw_stripped = read_fw_stripped + " 1:N:10:"
-                read_rv_stripped = read_rv_stripped + " 2:N:10:"
-                read_renamed = [read_fw_stripped,read_rv_stripped]
-        else:
-            sys.exit("The headers were not matching the patterns!")
-        return (read_dict,read_renamed)
-
-    def renameReadSingle(read):
-        read_dict = {}
-        if "/1" in read and " " not in read:
-            read_fw_stripped = read.strip("1").strip("/")
-            read_dict[read_fw_stripped] = [read]
-            read_fw_stripped = read_fw_stripped + " 1:N:10:"
-            read_renamed = [read_fw_stripped]
-        elif "/1" in read and " " in read:
-            read_fw_stripped = read.strip("1").strip("/").split(" ")[0]
-            read_dict[read_fw_stripped] = [read]
-            read_fw_stripped = read_fw_stripped + " 1:N:10:"
-            read_renamed = [read_fw_stripped]
-        elif " 1:" in read:
-            read_fw_stripped = read.split(" ")[0]
-            read_dict[read_fw_stripped] = [read]
-            read_fw_stripped = read_fw_stripped + " 1:N:10:"
-            read_renamed = [read_fw_stripped]
-        elif " " in read:
-            read_fw_stripped = read.split(" ")[0]
-            read_dict[read_fw_stripped] = [read]
-            read_fw_stripped = read_fw_stripped + " 1:N:10:"
-            read_renamed = [read_fw_stripped]
-        else:
-            sys.exit("The headers were not matching the patterns!")
-        return (read_dict,read_renamed)
-
-    def get_version():
-        version_output = subprocess.getoutput('python --version')
-        version = version_output.split()[1]
-        return version
-
-    fastq = "${inputfastq}".split(" ")
-    if len(fastq) == 2:
-        renamed = {}
-        with gzip.open(fastq[0], "rt") as handle1, gzip.open(fastq[1], "rt") as handle2:
-            with bgzf.BgzfWriter("${meta.id}_R1_renamed.fastq.gz", "wb") as outgz1, bgzf.BgzfWriter("${meta.id}_R2_renamed.fastq.gz", "wb") as outgz2:
-                for i,j in zip(SeqIO.parse(handle1, "fastq"),SeqIO.parse(handle2, "fastq")):
-                    header_fw = i.description
-                    header_rv = j.description
-                    headers = (header_fw,header_rv)
-                    headers = renameReadsPaired(headers)
-                    renamed.update(headers[0])
-                    i.description = headers[1][0]
-                    i.id = headers[1][0].split(" ")[0]
-                    j.description = headers[1][1]
-                    j.id = headers[1][1].split(" ")[0]
-                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
-                    SeqIO.write(sequences=j, handle=outgz2, format="fastq")
-        with open("${meta.id}_headers.json", "w") as outfile:
-            json.dump(renamed, outfile)
-    else:
-        renamed = {}
-        with gzip.open(fastq[0], "rt") as handle1:
-            with bgzf.BgzfWriter("${meta.id}_renamed.fastq.gz", "wb") as outgz1:
-                for i in SeqIO.parse(handle1, "fastq"):
-                    header_fw = i.description
-                    headers = renameReadSingle(header_fw)
-                    renamed.update(headers[0])
-                    i.description = headers[1][0]
-                    i.id = headers[1][0].split(" ")[0]
-                    SeqIO.write(sequences=i, handle=outgz1, format="fastq")
-        with open("${meta.id}_headers.json", "w") as outfile:
-            json.dump(renamed, outfile)
-
-    with open('versions.yml', 'w') as f:
-        f.write(f'"{subprocess.getoutput("echo ${task.process}")}":\\n')
-        f.write(f'    python: {get_version()}\\n')
-        f.write(f'    biopython: {Bio.__version__}\\n')
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+        biopython: \$(python -c "import pkg_resources; print(pkg_resources.get_distribution('biopython').version)")
+    END_VERSIONS
     """
 }


### PR DESCRIPTION
<!--
# nf-core/detaxizer pull request

Many thanks for contributing to nf-core/detaxizer!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).

## Restructuring
To prettify the code of the renaming modules the scripts were moved to separate `.py` files and the `bin/` folder.

## Gzipping json header dicts in the renaming steps
To reduce the amount of storage space used by the json header dictionaries the file is now gzipped and unzipped in the respective scripts.