### PR TITLE
fix: handel missing blastn files in summarizer

### DIFF
--- a/modules/local/summarizer.nf
+++ b/modules/local/summarizer.nf
@@ -33,12 +33,14 @@ process SUMMARIZER {
 
     kraken2_dfs = [pd.read_csv(file, sep="\\t", index_col=0) for file in files_kraken2]
     df_kraken2 = pd.concat(kraken2_dfs)
-
-    blastn_dfs = [pd.read_csv(file, sep="\\t", index_col=0) for file in files_blastn]
-    df_blastn = pd.concat(blastn_dfs)
-
-    summary_df = df_kraken2.join(df_blastn)
-    summary_df.to_csv("summary.tsv", sep="\\t")
+    if files_blastn != []:
+        blastn_dfs = [pd.read_csv(file, sep="\\t", index_col=0) for file in files_blastn]
+        df_blastn = pd.concat(blastn_dfs)
+        summary_df = df_kraken2.join(df_blastn)
+        summary_df.to_csv("summary.tsv", sep="\\t")
+    else:
+        summary_df = df_kraken2
+        summary_df.to_csv("summary.tsv", sep="\\t")
 
     # Generate the version.yaml for MultiQC
     with open('versions.yml', 'w') as f:

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -478,7 +478,7 @@ workflow DETAXIZER {
             item -> [['id': "summary_of_kraken2_and_blastn"], item]
         }
     } else {
-        ch_summary = ch_kraken2_summary.map {
+        ch_summary = ch_kraken2_summary.collect().map {
             item -> [['id': "summary_of_kraken2"], item]
         }
     }


### PR DESCRIPTION
<!--
# nf-core/detaxizer pull request

Many thanks for contributing to nf-core/detaxizer!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).

## Fix of summarizer
The summarizer module did fail using the `--skip_blastn` flag because of non-handled missing files. This has been fixed. Also a `.collect()` operator was missing when running the summarizer in the mentioned mode leading to execution on single files. This has also been fixed.