### PR TITLE
Corrections release1.0.0 - II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - Kobbfarbad - [2024-03-22]
+## v1.0.0 - Kobbfarbad - [2024-03-25]
 
 Initial release of nf-core/detaxizer, created with the [nf-core](https://nf-co.re/) template.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - Kobbfarbad - [2024-03-20]
+## v1.0.0 - Kobbfarbad - [2024-03-21]
 
 Initial release of nf-core/detaxizer, created with the [nf-core](https://nf-co.re/) template.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - Kobbfarbad - [2024-03-25]
+## v1.0.0 - Kobbfarbad - [2024-03-26]
 
 Initial release of nf-core/detaxizer, created with the [nf-core](https://nf-co.re/) template.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - Kobbfarbad - [2024-03-21]
+## v1.0.0 - Kobbfarbad - [2024-03-22]
 
 Initial release of nf-core/detaxizer, created with the [nf-core](https://nf-co.re/) template.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -19,7 +19,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
 
-Only the filtering results, the summary, MultiQC and Pipeline information are shown by default in the results folder.
+Only the filtering results, the summary, MultiQC and pipeline information are shown by default in the results folder.
 
 ### FastQC
 

--- a/main.nf
+++ b/main.nf
@@ -21,18 +21,6 @@ include { DETAXIZER               } from './workflows/detaxizer'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_detaxizer_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_detaxizer_pipeline'
 
-include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_detaxizer_pipeline'
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    GENOME PARAMETER VALUES
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-//   This is an example of how to use getGenomeAttribute() to fetch parameters
-//   from igenomes.config using `--genome`
-params.fasta = getGenomeAttribute('fasta')
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     NAMED WORKFLOWS FOR PIPELINE

--- a/modules.json
+++ b/modules.json
@@ -17,7 +17,7 @@
                     },
                     "fastp": {
                         "branch": "master",
-                        "git_sha": "003920c7f9a8ae19b69a97171922880220bedf56",
+                        "git_sha": "95cf5fe0194c7bf5cb0e3027a2eb7e7c89385080",
                         "installed_by": ["modules"]
                     },
                     "fastqc": {
@@ -27,7 +27,7 @@
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
-                        "git_sha": "8fae4ee738f645812384d6aba9d0dc651ad79ff9",
+                        "git_sha": "653218e79ffa76fde20319e9062f8b8da5cf7555",
                         "installed_by": ["modules"]
                     },
                     "multiqc": {

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -29,7 +29,7 @@ process FASTP {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
-    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
+    def fail_fastq = save_trimmed_fail && meta.single_end ? "--failed_out ${prefix}.fail.fastq.gz" : save_trimmed_fail && !meta.single_end ? "--failed_out ${prefix}.paired.fail.fastq.gz --unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
     // Added soft-links to original fastqs for consistent naming in MultiQC
     // Use single ended for interleaved. Add --interleaved_in in config.
     if ( task.ext.args?.contains('--interleaved_in') ) {

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -251,7 +251,8 @@ nextflow_process {
     }
 
     test("fastp test_fastp_interleaved") {
-        config './nextflow.config'
+
+        config './nextflow.interleaved.config'
         when {
             params {
                 outdir   = "$outputDir"
@@ -277,7 +278,7 @@ nextflow_process {
             def html_text  = [ "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)",
 									"paired end (151 cycles + 151 cycles)"]
             def log_text   = [ "Q20 bases: 12922(92.9841%)",
-									"reads passed filter: 198"]
+									"reads passed filter: 162"]
             def read_lines = [ "@ERR5069949.2151832 NS500628:121:HK3MMAFX2:2:21208:10793:15304/1",
 									"TCATAAACCAAAGCACTCACAGTGTCAACAATTTCAGCAGGACAACGCCGACAAGTTCCGAGGAACATGTCTGGACCTATAGTTTTCATAAGTCTACACACTGAATTGAAATATTCTGGTTCTAGTGTGCCCTTAGTTAGCAATGTGCGT",
 									"AAAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEE<EEAAAEEEEEEEEEAAAAEAEEEAEEEEEE<AAAA",
@@ -321,7 +322,7 @@ nextflow_process {
 
         options '-stub'
 
-        config './nextflow.config'
+        config './nextflow.interleaved.config'
         when {
             params {
                 outdir   = "$outputDir"
@@ -427,6 +428,7 @@ nextflow_process {
 
     test("test_fastp_paired_end_trim_fail") {
 
+        config './nextflow.save_failed.config'
         when {
             params {
                 outdir   = "$outputDir"
@@ -454,7 +456,7 @@ nextflow_process {
 									"The input has little adapter percentage (~0.000000%), probably it's trimmed before."]
             def log_text            = [ "No adapter detected for read1",
 									"Q30 bases: 12281(88.3716%)"]
-            def json_text           = ['"passed_filter_reads": 198']
+            def json_text           = ['"passed_filter_reads": 162']
             def read1_lines         = ["@ERR5069949.2151832 NS500628:121:HK3MMAFX2:2:21208:10793:15304/1",
 									"TCATAAACCAAAGCACTCACAGTGTCAACAATTTCAGCAGGACAACGCCGACAAGTTCCGAGGAACATGTCTGGACCTATAGTTTTCATAAGTCTACACACTGAATTGAAATATTCTGGTTCTAGTGTGCCCTTAGTTAGCAATGTGCGT",
 									"AAAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAAEEEEE<EEAAAEEEEEEEEEAAAAEAEEEAEEEEEE<AAAA",
@@ -467,9 +469,9 @@ nextflow_process {
 									"@ERR5069949.576388 NS500628:121:HK3MMAFX2:4:11501:11167:14939/2",
 									"GCATAGACGGTGCTTTACTTACAAAGTCCTCAGAATACAAAGGTCCTATTACGGATGTTTTCTACAAAGAAAACAGT",
 									"AAAAA6EEAEEEEEAEEAEEAEEEEEEA6EEEEAEEAEEEEE6EEEEEEAEEEEA///A<<EEEEEEEEEAEEEEEE"]
-            def failed_read2_lines  = ["@ERR5069949.885966 NS500628:121:HK3MMAFX2:4:11610:19682:20132/2",
-									"CTTAGGTCTTAGGATTGGCTGTATCAACCTTAAGCTTAAGTACACAATTTTGCATAGAATGTCCAATAA",
-									"A//AA6EEAEEEEE6EEE/EEA/EA///AAE/EAEEEAE6AE/E/E/EEAAE/EAA/E/E/<EA//E/6"]
+            def failed_read2_lines  = ["@ERR5069949.973930 NS500628:121:HK3MMAFX2:2:21105:5548:5659/2",
+									"CCTTTTGATGTTGTTAGACAATGCTCAGGTGTTACTTTCCAAAGTGCAGTGAAAAGAACAATCAAGGGTACACACCACTGGTTGTTACTCACAATTTTGACTTCACTTTTAG",
+									"AAAAAEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE/EEEEEEEEEEEEEEEEEEEEEEEAE<EAEEEEEEAEEAEE"]
             // def failed_read1_lines = path(process.out.reads_fail.get(0).get(1).get(0)).linesGzip is empty file
             assertAll(
                 { assert process.success },
@@ -483,7 +485,7 @@ nextflow_process {
                     }
                 },
                 { failed_read2_lines.each { failed_read2_line ->
-                    { assert path(process.out.reads_fail.get(0).get(1).get(1)).linesGzip.contains(failed_read2_line) }
+                    { assert path(process.out.reads_fail.get(0).get(1).get(2)).linesGzip.contains(failed_read2_line) }
                     }
                 },
                 { html_text.each { html_part ->

--- a/modules/nf-core/fastp/tests/main.nf.test.snap
+++ b/modules/nf-core/fastp/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.fastp.json:md5,168f516f7bd4b7b6c32da7cba87299a4"
+                    "test.fastp.json:md5,b24e0624df5cc0b11cd5ba21b726fb22"
                 ]
             ]
         ],
@@ -15,7 +15,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-17T18:08:06.123035"
+        "timestamp": "2024-03-18T16:19:15.063001"
     },
     "test_fastp_paired_end_merged-for_stub_match": {
         "content": [
@@ -65,7 +65,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-17T18:06:00.223817"
+        "timestamp": "2024-03-18T16:18:43.526412"
     },
     "versions_paired_end": {
         "content": [
@@ -112,7 +112,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T12:03:37.827323085"
+        "timestamp": "2024-03-18T16:19:15.111894"
     },
     "test_fastp_paired_end_merged_match": {
         "content": [
@@ -283,7 +283,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T11:57:30.791982648"
+        "timestamp": "2024-03-18T16:18:43.580336"
     },
     "versions_paired_end_merged_adapterlist": {
         "content": [

--- a/modules/nf-core/fastp/tests/nextflow.interleaved.config
+++ b/modules/nf-core/fastp/tests/nextflow.interleaved.config
@@ -1,0 +1,5 @@
+process {
+    withName: FASTP {
+        ext.args = "--interleaved_in -e 30"
+    }
+}

--- a/modules/nf-core/fastp/tests/nextflow.save_failed.config
+++ b/modules/nf-core/fastp/tests/nextflow.save_failed.config
@@ -1,6 +1,5 @@
 process {
-
     withName: FASTP {
-        ext.args = "--interleaved_in"
+        ext.args = "-e 30"
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-includeConfig 'conf/igenomes.config'
+
 // Global default params, used in configs
 params {
 

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -35,14 +35,14 @@ include { SUMMARIZER                            } from '../modules/local/summari
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// speficy the fasta parameter if it is not provided via --fasta
-def fasta = false
+// speficy the fasta channel if it is not provided via --fasta
+def fasta = Channel.empty()
 
-if (!params.fasta) {
-    fasta = getGenomeAttribute('fasta')
-} else {
+if (!params.fasta && !params.skip_blastn) {
+    fasta = Channel.fromPath(getGenomeAttribute('fasta'))
+} else if (!params.skip_blastn){
     // If params.fasta is there, use it for the creation of the blastn database
-    fasta = params.fasta
+    fasta = Channel.fromPath(params.fasta)
 }
 
 workflow DETAXIZER {
@@ -207,7 +207,7 @@ workflow DETAXIZER {
         //
         // MODULE: Run BLASTN
         //
-        ch_reference_fasta = Channel.fromPath( fasta )
+        ch_reference_fasta = fasta
 
         ch_reference_fasta_with_meta = ch_reference_fasta.map {
             item -> [['id': "id-fasta-for-makeblastdb"], item]

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -11,6 +11,7 @@ include { paramsSummaryMap       } from 'plugin/nf-validation'
 include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_detaxizer_pipeline'
+include { getGenomeAttribute     } from '../subworkflows/local/utils_nfcore_detaxizer_pipeline'
 
 include { FASTP             } from '../modules/nf-core/fastp/main'
 include { KRAKEN2_KRAKEN2   } from '../modules/nf-core/kraken2/kraken2/main'
@@ -38,12 +39,9 @@ include { SUMMARIZER                            } from '../modules/local/summari
 def fasta = false
 
 if (!params.fasta) {
-    // If params.fasta is false and params.genome is present
-    if (params.genome) {
-        fasta = params.genomes[params.genome]?.fasta ?: false
-    }
+    fasta = getGenomeAttribute('fasta')
 } else {
-    // If params.fasta is there, use it
+    // If params.fasta is there, use it for the creation of the blastn database
     fasta = params.fasta
 }
 
@@ -65,16 +63,9 @@ workflow DETAXIZER {
     ch_short.shortReads.map{
         meta, short_reads_fastq_1, short_reads_fastq_2, long_reads_fastq_1 ->
             if (short_reads_fastq_2){
-                def newMeta = meta.clone()
-                newMeta.single_end = false
-                newMeta.long_reads = false
-                return [newMeta, [short_reads_fastq_1, short_reads_fastq_2]]
+                return [meta + [ single_end: false, long_reads: false , amount_of_files: 2], [short_reads_fastq_1, short_reads_fastq_2]]
             } else {
-                def newMeta = meta.clone()
-                newMeta.id = "${newMeta.id}_R1"
-                newMeta.single_end = true
-                newMeta.long_reads = false
-                return [newMeta, short_reads_fastq_1]
+                return [meta + [id: "${meta.id}_R1", single_end: true, long_reads: false, amount_of_files: 1], short_reads_fastq_1]
             }
     }.set{
         ch_short
@@ -88,11 +79,7 @@ workflow DETAXIZER {
 
     ch_long.longReads.map {
         meta, short_reads_fastq_1, short_reads_fastq_2, long_reads_fastq_1 ->
-            def newMeta = meta.clone()
-            newMeta.id = "${newMeta.id}_longReads"
-            newMeta.single_end = true
-            newMeta.long_reads = true
-            return [newMeta, long_reads_fastq_1]
+            return [meta + [id: "${meta.id}_longReads", single_end: true, long_reads: true, amount_of_files: 1], long_reads_fastq_1]
     }.set {
         ch_long
     }
@@ -175,15 +162,15 @@ workflow DETAXIZER {
     //
     ch_prepare_summary_kraken2 = KRAKEN2_KRAKEN2.out.classified_reads_assignment.join(ISOLATE_IDS_FROM_KRAKEN2_TO_BLASTN.out.classified).map {
         meta, path1, path2 ->
-            def newMeta = meta.clone()
-            return [ newMeta, [ path1, path2 ] ]
+            return [ meta, [ path1, path2 ] ]
     }
 
     ch_combined_kraken2 = ch_prepare_summary_kraken2.map {
         meta, path ->
-            def newMeta = meta.clone()
-            newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-            return [ newMeta , path]
+            return [ meta +[id: meta.id.replaceAll("(_R1|_R2)", "")] , path]
+        }
+        .map{
+            meta, path -> tuple( groupKey(meta, meta.amount_of_files), path )
         }
         .groupTuple(by: [0])
         .map {
@@ -238,13 +225,13 @@ workflow DETAXIZER {
             .flatMap { meta, fastaList ->
                 if (fastaList.size() == 2) {
                 return [
-                    [ [ 'id': "${meta.id}_R1", 'single_end': false, 'long_reads': false ], fastaList[0] ],
-                    [ [ 'id': "${meta.id}_R2", 'single_end': false, 'long_reads': false ], fastaList[1] ]
+                    [ meta + [ id: "${meta.id}_R1" ], fastaList[0] ],
+                    [ meta + [ id: "${meta.id}_R2" ], fastaList[1] ]
                 ]
 
                 } else {
                     return [
-                        [ [ 'id': "${meta.id}", 'single_end': true, 'long_reads': meta.long_reads ], fastaList ] ]
+                        [ meta , fastaList ] ]
                 }
 
             }
@@ -260,12 +247,10 @@ workflow DETAXIZER {
 
         ch_combined_blast = BLAST_BLASTN.out.txt.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path ]
-        }
-
-        ch_combined_blast = ch_combined_blast.groupTuple(
+                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+        }.map{
+            meta, path -> tuple( groupKey(meta, meta.amount_of_files), path )
+        }.groupTuple(
                 by: [0]
             ).map {
                 meta, paths -> [ meta, paths.flatten() ]
@@ -278,9 +263,9 @@ workflow DETAXIZER {
 
         ch_filtered_combined = FILTER_BLASTN_IDENTCOV.out.classified.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path ]
+                return [meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+        }.map{
+            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
         .groupTuple ()
         .map {
@@ -337,16 +322,15 @@ workflow DETAXIZER {
         ) {
         ch_blastn2filter = FILTER_BLASTN_IDENTCOV.out.classified_ids.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path]
+                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+        }
+        .map{
+            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
         .groupTuple(by:[0])
         ch_combined_short_long_id = RENAME_FASTQ_HEADERS_PRE.out.fastq.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path]
+                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
         }
         ch_blastnfilter = ch_combined_short_long_id.join(
             ch_blastn2filter, by:[0]
@@ -371,16 +355,15 @@ workflow DETAXIZER {
     ){
         ch_blastn2filter = FILTER_BLASTN_IDENTCOV.out.classified_ids.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path]
+                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+        }
+        .map{
+            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
         .groupTuple(by:[0])
         ch_combined_short_long_id = FASTP.out.reads.map {
             meta, path ->
-                def newMeta = meta.clone()
-                newMeta.id = newMeta.id.replaceAll("(_R1|_R2)", "")
-                return [ newMeta, path]
+                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
         }
         ch_blastnfilter = ch_combined_short_long_id.join(
             ch_blastn2filter, by:[0]
@@ -397,16 +380,12 @@ workflow DETAXIZER {
     if ( params.enable_filter ) {
     ch_headers = RENAME_FASTQ_HEADERS_PRE.out.headers.map {
         meta, path ->
-            def newMeta = meta.clone()
-            newMeta.id  = newMeta.id.replaceAll("(_R1|_R2)", "")
-            return [ newMeta, path ]
+            return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
     }
 
     ch_filtered2rename = FILTER.out.filtered.map {
         meta, path ->
-            def newMeta = meta.clone()
-            newMeta.id  = newMeta.id.replaceAll("(_R1|_R2)", "")
-            return [ newMeta, path ]
+            return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
     }
 
     ch_rename_filtered = ch_filtered2rename.join(ch_headers, by:[0])
@@ -418,7 +397,6 @@ workflow DETAXIZER {
     //
     // MODULE: Summarize the classification process
     //
-
     if (!params.skip_blastn){
     ch_summary = ch_kraken2_summary.mix(ch_blastn_summary).collect().map {
             item -> [['id': "summary_of_kraken2_and_blastn"], item]

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -245,8 +245,6 @@ workflow DETAXIZER {
         ch_combined_blast = BLAST_BLASTN.out.txt.map {
             meta, path ->
                 return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
-        }.map{
-            meta, path -> tuple( groupKey(meta, meta.amount_of_files), path )
         }.groupTuple(
                 by: [0]
             ).map {
@@ -261,10 +259,8 @@ workflow DETAXIZER {
         ch_filtered_combined = FILTER_BLASTN_IDENTCOV.out.classified.map {
             meta, path ->
                 return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
-        }.map{
-            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
-        .groupTuple ()
+        .groupTuple (by: [0])
         .map {
             meta, paths ->
                 paths = paths.flatten()

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -169,7 +169,6 @@ workflow DETAXIZER {
         meta, path ->
             return [ meta +[ id: meta.id.replaceAll("(_R1|_R2)", "") ] , path]
         }
-        .groupTuple(by: [0])
         .map {
             meta, path ->
                 path = path.flatten()
@@ -245,7 +244,11 @@ workflow DETAXIZER {
         ch_combined_blast = BLAST_BLASTN.out.txt.map {
             meta, path ->
                 return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
-        }.groupTuple(
+        }
+        .map{
+            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
+        }
+        .groupTuple(
                 by: [0]
             ).map {
                 meta, paths -> [ meta, paths.flatten() ]
@@ -259,6 +262,9 @@ workflow DETAXIZER {
         ch_filtered_combined = FILTER_BLASTN_IDENTCOV.out.classified.map {
             meta, path ->
                 return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
+        }
+        .map{
+            meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
         .groupTuple (by: [0])
         .map {
@@ -354,6 +360,7 @@ workflow DETAXIZER {
             meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
         .groupTuple(by:[0])
+
         ch_combined_short_long_id = FASTP.out.reads.map {
             meta, path ->
                 return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -63,9 +63,9 @@ workflow DETAXIZER {
     ch_short.shortReads.map{
         meta, short_reads_fastq_1, short_reads_fastq_2, long_reads_fastq_1 ->
             if (short_reads_fastq_2){
-                return [meta + [ single_end: false, long_reads: false , amount_of_files: 2], [short_reads_fastq_1, short_reads_fastq_2]]
+                return [meta + [ single_end: false, long_reads: false , amount_of_files: 2 ], [ short_reads_fastq_1, short_reads_fastq_2 ] ]
             } else {
-                return [meta + [id: "${meta.id}_R1", single_end: true, long_reads: false, amount_of_files: 1], short_reads_fastq_1]
+                return [meta + [ id: "${meta.id}_R1", single_end: true, long_reads: false, amount_of_files: 1 ], short_reads_fastq_1 ]
             }
     }.set{
         ch_short
@@ -79,7 +79,7 @@ workflow DETAXIZER {
 
     ch_long.longReads.map {
         meta, short_reads_fastq_1, short_reads_fastq_2, long_reads_fastq_1 ->
-            return [meta + [id: "${meta.id}_longReads", single_end: true, long_reads: true, amount_of_files: 1], long_reads_fastq_1]
+            return [meta + [ id: "${meta.id}_longReads", single_end: true, long_reads: true, amount_of_files: 1 ], long_reads_fastq_1 ]
     }.set {
         ch_long
     }
@@ -167,10 +167,7 @@ workflow DETAXIZER {
 
     ch_combined_kraken2 = ch_prepare_summary_kraken2.map {
         meta, path ->
-            return [ meta +[id: meta.id.replaceAll("(_R1|_R2)", "")] , path]
-        }
-        .map{
-            meta, path -> tuple( groupKey(meta, meta.amount_of_files), path )
+            return [ meta +[ id: meta.id.replaceAll("(_R1|_R2)", "") ] , path]
         }
         .groupTuple(by: [0])
         .map {
@@ -247,7 +244,7 @@ workflow DETAXIZER {
 
         ch_combined_blast = BLAST_BLASTN.out.txt.map {
             meta, path ->
-                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }.map{
             meta, path -> tuple( groupKey(meta, meta.amount_of_files), path )
         }.groupTuple(
@@ -263,7 +260,7 @@ workflow DETAXIZER {
 
         ch_filtered_combined = FILTER_BLASTN_IDENTCOV.out.classified.map {
             meta, path ->
-                return [meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }.map{
             meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
         }
@@ -288,7 +285,7 @@ workflow DETAXIZER {
                 if (filteredblastn[1] == null){
                     filteredblastn[1] = []
                 }
-                return [meta, blastn[0], blastn[1], filteredblastn[0], filteredblastn[1]]
+                return [ meta, blastn[0], blastn[1], filteredblastn[0], filteredblastn[1] ]
             }
 
         ch_blastn_summary = SUMMARY_BLASTN (
@@ -322,7 +319,7 @@ workflow DETAXIZER {
         ) {
         ch_blastn2filter = FILTER_BLASTN_IDENTCOV.out.classified_ids.map {
             meta, path ->
-                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }
         .map{
             meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
@@ -330,7 +327,7 @@ workflow DETAXIZER {
         .groupTuple(by:[0])
         ch_combined_short_long_id = RENAME_FASTQ_HEADERS_PRE.out.fastq.map {
             meta, path ->
-                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }
         ch_blastnfilter = ch_combined_short_long_id.join(
             ch_blastn2filter, by:[0]
@@ -355,7 +352,7 @@ workflow DETAXIZER {
     ){
         ch_blastn2filter = FILTER_BLASTN_IDENTCOV.out.classified_ids.map {
             meta, path ->
-                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }
         .map{
             meta, path -> tuple(groupKey(meta, meta.amount_of_files), path)
@@ -363,7 +360,7 @@ workflow DETAXIZER {
         .groupTuple(by:[0])
         ch_combined_short_long_id = FASTP.out.reads.map {
             meta, path ->
-                return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path]
+                return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
         }
         ch_blastnfilter = ch_combined_short_long_id.join(
             ch_blastn2filter, by:[0]
@@ -380,12 +377,12 @@ workflow DETAXIZER {
     if ( params.enable_filter ) {
     ch_headers = RENAME_FASTQ_HEADERS_PRE.out.headers.map {
         meta, path ->
-            return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+            return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
     }
 
     ch_filtered2rename = FILTER.out.filtered.map {
         meta, path ->
-            return [ meta + [id: meta.id.replaceAll("(_R1|_R2)", "")], path ]
+            return [ meta + [ id: meta.id.replaceAll("(_R1|_R2)", "") ], path ]
     }
 
     ch_rename_filtered = ch_filtered2rename.join(ch_headers, by:[0])


### PR DESCRIPTION
<!--
# nf-core/detaxizer pull request

Many thanks for contributing to nf-core/detaxizer!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.

# Corrections release 1.0.0 - II
- `fastp` and `kraken2` modules were updated to newest version
- `groupTuple` was extended by `groupKey` to avoid bottlenecks in the pipeline runs, for this an `amount_of_files` entry was added to the meta maps
- `meta.clone()` was replaced with `meta + [changes]`
- `getGenomeAttribute` was moved to `detaxizer.nf` as replacement for logic checking if the genome parameter is in the `igenomes.config` and if the `fasta`attribute is included in this genome entry
- removed doubling of inclusion of `igenomes.config` into `nextflow.config`
- date of release in `CHANGELOG.md` was updated