### PR TITLE
Fix for bug #32 by addition of quotation marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
+
 - [#32](https://github.com/nf-core/detaxizer/issues/32) - Addition of quotation marks in `parse_kraken2report.nf` prevents failure of the pipeline when using a taxon with space (e.g. Homo sapiens) with the `tax2filter` parameter.
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
+- [#32](https://github.com/nf-core/detaxizer/issues/32) - Addition of quotation marks in `parse_kraken2report.nf` prevents failure of the pipeline when using a taxon with space (e.g. Homo sapiens) with the `tax2filter` parameter.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#32](https://github.com/nf-core/detaxizer/issues/32) - Addition of quotation marks in `parse_kraken2report.nf` prevents failure of the pipeline when using a taxon with space (e.g. Homo sapiens) with the `tax2filter` parameter.
+- [PR #33](https://github.com/nf-core/detaxizer/pull/33) - Addition of quotation marks in `parse_kraken2report.nf` prevents failure of the pipeline when using a taxon with space (e.g. Homo sapiens) with the `tax2filter` parameter.
 
 ### `Dependencies`
 

--- a/modules/local/parse_kraken2report.nf
+++ b/modules/local/parse_kraken2report.nf
@@ -19,7 +19,7 @@ process PARSE_KRAKEN2REPORT {
 
     script:
     """
-    parse_kraken2report.py -i $kraken2report -t $params.tax2filter
+    parse_kraken2report.py -i $kraken2report -t "$params.tax2filter"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
<!--
# nf-core/detaxizer pull request

Many thanks for contributing to nf-core/detaxizer!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
-->
The bug #32 was fixed by addition of quotation marks to `parse_kraken2report.nf`. The wished behavior cannot be tested via the test dataset as the `minigut_kraken` DB has only `unclassified` in it. Though, it can be tested locally with following changes to the `test.config`: setting `max_memory` to `10.GB`, using the kraken2 [HPRC DB](https://zenodo.org/records/8339732) for the `kraken2db` parameter (value is `https://zenodo.org/records/8339732/files/k2_HPRC_20230810.tar.gz`) and finally setting the `tax2filter` parameter to `Homo sapiens`.
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/detaxizer _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
