### PR TITLE
Adjust default to best decontamination setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [PR #70](https://github.com/nf-core/detaxizer/pull/70) - Filtering is now default, `--skip_filter` was added
-- [PR #71](https://github.com/nf-core/detaxizer/pull/71) - Add usage information learned from our benchmarking
+- [PR #70](https://github.com/nf-core/detaxizer/pull/70) - Filtering is now default, `--skip_filter` was added (by @d4straub)
+- [PR #71](https://github.com/nf-core/detaxizer/pull/71) - Add usage information learned from our benchmarking (by @d4straub)
 
 ### `Changed`
 
 - [PR #65](https://github.com/nf-core/detaxizer/pull/65),[PR #69](https://github.com/nf-core/detaxizer/pull/69) - Template update for nf-core/tools 3.3.2 (by @d4straub)
+- [PR #72](https://github.com/nf-core/detaxizer/pull/72) - Default for `--kraken2db` was changed from 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz' to 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz'. That new database is much larger (60GB) but default settings will therefore reflect best decontamination performance in benchmarks (by @d4straub)
 
 ### `Fixed`
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Deprecated`
 
-- [PR #70](https://github.com/nf-core/detaxizer/pull/70) - Filtering is now default, `--enable_filter` was removed and replaced by `--skip_filter`
+- [PR #70](https://github.com/nf-core/detaxizer/pull/70) - Filtering is now default, `--enable_filter` was removed and replaced by `--skip_filter` (by @d4straub)
 
 ## v1.1.0 - Kombjuudr - [2024-11-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [PR #65](https://github.com/nf-core/detaxizer/pull/65),[PR #69](https://github.com/nf-core/detaxizer/pull/69) - Template update for nf-core/tools 3.3.2 (by @d4straub)
-- [PR #72](https://github.com/nf-core/detaxizer/pull/72) - Default for `--kraken2db` was changed from 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz' to 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz'. That new database is much larger (60GB) but default settings will therefore reflect best decontamination performance in benchmarks (by @d4straub)
+- [PR #72](https://github.com/nf-core/detaxizer/pull/72) - Default for `--kraken2db` was changed from 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz' to 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz'. That database is much larger (60GB) but default settings will therefore reflect best decontamination performance in benchmarks (by @d4straub)
 
 ### `Fixed`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,7 +42,7 @@ process {
     }
     withLabel:process_high {
         cpus   = { 12    * task.attempt }
-        memory = { 72.GB * task.attempt }
+        memory = { 80.GB * task.attempt }
         time   = { 16.h  * task.attempt }
     }
     withLabel:process_long {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,19 +10,16 @@ nf-core/detaxizer is a pipeline to assess raw (meta)genomic data for contaminati
 
 ## Benchmark
 
-Benchmarking with an [artificial real metagenomic reads dataset](https://doi.org/10.5281/zenodo.10472795) is described in this [publication](https://doi.org/10.1101/2025.03.27.645632). The best performing decontamination was achieved by nf-core/detaxizer with the combination of bbduk with GRCh38 AWS igenome and Kraken2 with the Kraken2 Standard database. This setting reached a recall of 0.99962 (3,770 false negatives of 10,000,002 human read pairs) but a precision of 0.99150 (85,741 false positives of 21,172,961 microbial read pairs). The following settings were used with nf-core/detaxizer 1.1.0:
+Benchmarking with an [artificial real metagenomic reads dataset](https://doi.org/10.5281/zenodo.10472795) is described in this [publication](https://doi.org/10.1101/2025.03.27.645632) with nf-core/detaxizer 1.1.0. The best performing decontamination was achieved by nf-core/detaxizer with the combination of bbduk with GRCh38 AWS igenome and Kraken2 with the Kraken2 Standard database. This setting reached a recall of 0.99962 (3,770 false negatives of 10,000,002 human read pairs) but a precision of 0.99150 (85,741 false positives of 21,172,961 microbial read pairs). The following command mirrors the settings in the benchmark (but with version 1.2.0 instead of 1.1.0):
 
 ```bash
-`NXF_VER=24.04.4 nextflow run nf-core/detaxizer -r 1.1.0 -profile singularity --input samplesheet.csv --enable_filter --output_removed_reads --tax2filter "Homo sapiens" --classification_bbduk --classification_kraken2 --kraken2db https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz --outdir results`
+`NXF_VER=24.04.4 nextflow run nf-core/detaxizer -r 1.2.0 -profile singularity --input samplesheet.csv --classification_bbduk --classification_kraken2 --outdir results_recall`
 ```
 
-> [!NOTE]
-> From version 1.2.0 on filtering is enabled by default and therefore `--enable_filter` is neither required nor allowed.
-
-To best retention of microbial reads (precision of 0.99922 = 7,654 false positives of 21 million microbial read pairs) at the cost of higher non-detected human reads (recall of 0.99303 = 69,725 false negatives of 10 million human read pairs) was achieved in the [benchmark](https://doi.org/10.1101/2025.03.27.645632) with the following settings:
+To best retention of microbial reads (precision of 0.99922 = 7,654 false positives of 21 million microbial read pairs) at the cost of higher non-detected human reads (recall of 0.99303 = 69,725 false negatives of 10 million human read pairs) was achieved in the [benchmark](https://doi.org/10.1101/2025.03.27.645632) with the following settings (translated from version 1.1.0 to version 1.2.0):
 
 ```bash
-`NXF_VER=24.04.4 nextflow run nf-core/detaxizer -r 1.1.0 -profile singularity --input samplesheet.csv --enable_filter --output_removed_reads --tax2filter "Homo sapiens" --classification_kraken2 --kraken2db https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240605.tar.gz --outdir results`
+`NXF_VER=24.04.4 nextflow run nf-core/detaxizer -r 1.2.0 -profile singularity --input samplesheet.csv --classification_kraken2 --kraken2db https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240605.tar.gz --outdir results_precision`
 ```
 
 > [!TIP]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,7 @@ The task of decontamination has to be balanced out between false positives and f
 
 ### kraken2
 
-To reduce false negatives a larger kraken2 database should be used. This comes at costs in terms of hardware requirements. For the largest kraken2 standard database (which can be found [here](https://benlangmead.github.io/aws-indexes/k2)) at least 100 GB of memory should be available, depending on the size of your data the required memory may be higher. For standard decontamination tasks the Standard-8 GB database can be used (which is the default), but it should always be kept in mind that this may lead to false negatives to some extent.
+For optimal decontamination performance a large kraken2 database should be used. This comes at costs in terms of hardware requirements and download volumes. The default is a large database called "Standard", with ~60GB size and requires ~80GB RAM. For the largest kraken2 standard database (which can be found [here](https://benlangmead.github.io/aws-indexes/k2)) at least 100 GB of memory should be available, depending on the size of your data the required memory may be higher. For standard decontamination tasks the Standard-8 GB database (i.e. caped at 8GB) can be used, but it should always be kept in mind that this may lead to more false negatives (but conversely potentially less false positives).
 
 To build your own database refer to [this site](https://github.com/DerrickWood/kraken2/blob/master/docs/MANUAL.markdown#custom-databases).
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
     bbduk_kmers                = 27
 
     // Kraken2preparation parameter
-    kraken2db                  = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz'
+    kraken2db                  = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz'
 
     // Kraken2 parameter
     save_output_fastqs          = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -120,7 +120,7 @@
             "properties": {
                 "kraken2db": {
                     "type": "string",
-                    "default": "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz",
+                    "default": "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz",
                     "help_text": "For input how to use this parameter to fine-tune the step see the kraken2 section in the [usage documentation](https://nf-co.re/detaxizer/docs/usage#kraken2)",
                     "description": "The database which is used in the classification step."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -121,8 +121,8 @@
                 "kraken2db": {
                     "type": "string",
                     "default": "https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20240605.tar.gz",
-                    "help_text": "For input how to use this parameter to fine-tune the step see the kraken2 section in the [usage documentation](https://nf-co.re/detaxizer/docs/usage#kraken2)",
-                    "description": "The database which is used in the classification step."
+                    "help_text": "For input how to use this parameter to fine-tune the step see the kraken2 section in the [usage documentation](https://nf-co.re/detaxizer/docs/usage#kraken2). To reduce the required download and RAM by around 10 fold, rather use a database capped at e.g. 8 GB, for example https://genome-idx.s3.amazonaws.com/kraken/k2_standard_08gb_20240904.tar.gz.",
+                    "description": "The database which is used in the classification step. Please be aware that this default database will require ~60GB download and ~80GB RAM."
                 },
                 "save_output_fastqs": {
                     "type": "boolean",


### PR DESCRIPTION
Most users use pipelines with default settings. Therefore, default settings should reflect best performance, where possible. Here, the database for best human contamination removal (highest recall) is set to default. 
That comes at a cost though: The kraken2 database for the best performing setting is huge with ~60GB, compared to ~5GB before. The new default database will increase required RAM from ~8GB to ~80GB, a disadvantage. 
My reasoning for that change: when being lazy and not adjusting settings, the change might lead to computational bottlenecks but best decontamination (forcing diving into documentaion). Originally, there would not have been a computational bottleneck but the results would have been sub-optimal (in the worst case without realizing).

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/detaxizer _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
