### PR TITLE
Feature/new filtering tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [PR #80](https://github.com/nf-core/detaxizer/pull/80) - bbmap/filterbyname.sh natively handles pair-end reads, eliminating the steps required to modify fastq headers, improves run time, choose via `--filtering_tool` (by @m3hdad)
+
 ### `Changed`
 
 - [PR #79](https://github.com/nf-core/detaxizer/pull/79) - Update version to 1.3.0dev (by @d4straub)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -181,20 +181,22 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME {
+        ext.prefix = { "${meta.id}_filtered" }
         publishDir = [
             path: { "${params.outdir}/filter/filtered" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz',
+            pattern: '*_filtered_*.fastq.gz',
             enabled: params.filtering_tool == 'bbmap'
         ]
     }
 
     withName: BBMAP_FILTERBYNAME_REMOVED {
         ext.args = 'include=t'
+        ext.prefix = { "${meta.id}_removed" }
         publishDir = [
             path: { "${params.outdir}/filter/removed" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz',
+            pattern: '*_removed_*.fastq.gz',
             enabled: params.output_removed_reads && params.filtering_tool == 'bbmap'
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -190,6 +190,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME_REMOVED {
+        ext.args = 'include=t'
         publishDir = [
             path: { "${params.outdir}/filter/removed" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -181,7 +181,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME {
-        ext.args = 'include=f substring=name'
+        ext.args = 'include=f'
         ext.prefix = { "${meta.id}_filtered" }
         publishDir = [
             path: { "${params.outdir}/filter/filtered" },
@@ -192,7 +192,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME_REMOVED {
-        ext.args = 'include=t substring=name'
+        ext.args = 'include=t'
         ext.prefix = { "${meta.id}_removed" }
         publishDir = [
             path: { "${params.outdir}/filter/removed" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -186,7 +186,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/filter/filtered" },
             mode: params.publish_dir_mode,
-            pattern: '*_filtered_*.fastq.gz',
+            pattern: '*_filtered*.fastq.gz',
             enabled: params.filtering_tool == 'bbmap'
         ]
     }
@@ -197,7 +197,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/filter/removed" },
             mode: params.publish_dir_mode,
-            pattern: '*_removed_*.fastq.gz',
+            pattern: '*_removed*.fastq.gz',
             enabled: params.output_removed_reads && params.filtering_tool == 'bbmap'
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -181,6 +181,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME {
+        ext.args = 'include=f'
         ext.prefix = { "${meta.id}_filtered" }
         publishDir = [
             path: { "${params.outdir}/filter/filtered" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -181,7 +181,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME {
-        ext.args = 'include=f'
+        ext.args = 'include=f substring=name'
         ext.prefix = { "${meta.id}_filtered" }
         publishDir = [
             path: { "${params.outdir}/filter/filtered" },
@@ -192,7 +192,7 @@ process {
     }
 
     withName: BBMAP_FILTERBYNAME_REMOVED {
-        ext.args = 'include=t'
+        ext.args = 'include=t substring=name'
         ext.prefix = { "${meta.id}_removed" }
         publishDir = [
             path: { "${params.outdir}/filter/removed" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -180,6 +180,24 @@ process {
         ]]
     }
 
+    withName: BBMAP_FILTERBYNAME {
+        publishDir = [
+            path: { "${params.outdir}/filter/filtered" },
+            mode: params.publish_dir_mode,
+            pattern: '*.fastq.gz',
+            enabled: params.filtering_tool == 'bbmap'
+        ]
+    }
+
+    withName: BBMAP_FILTERBYNAME_REMOVED {
+        publishDir = [
+            path: { "${params.outdir}/filter/removed" },
+            mode: params.publish_dir_mode,
+            pattern: '*.fastq.gz',
+            enabled: params.output_removed_reads && params.filtering_tool == 'bbmap'
+        ]
+    }
+
     withName: SUMMARY_CLASSIFICATION {
         publishDir = [
             path: { "${params.outdir}/classification/summary" },

--- a/modules.json
+++ b/modules.json
@@ -11,6 +11,11 @@
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
                     },
+                    "bbmap/filterbyname": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
                     "blast/blastn": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",

--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -8,7 +8,7 @@ process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
         'biocontainers/python:3.10.4' }"
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(meta), path(reads), path(classification)
 
     output:
     tuple val(meta), path('*kraken2.map.txt'), emit: mapping
@@ -19,35 +19,41 @@ process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
 
     script:
     """
-    python - ${reads} ${meta.id}.kraken2.map.txt <<'PY'
+    python - ${reads} ${classification} ${meta.id}.kraken2.map.txt <<'PY'
 import gzip, sys
+
 
 def open_file(p):
     return gzip.open(p, 'rt') if p.endswith('.gz') else open(p, 'r')
 
-reads = sys.argv[1:-1]
+
+reads = sys.argv[1:-2]
+classification = sys.argv[-2]
 output = sys.argv[-1]
 
-with open(output, 'w') as out:
+
+with open_file(classification) as kc, open(output, 'w') as out:
     if len(reads) == 2:
         with open_file(reads[0]) as f1, open_file(reads[1]) as f2:
             while True:
-                h1 = f1.readline().rstrip()
-                h2 = f2.readline().rstrip()
-                if not h1 or not h2:
+                line = kc.readline()
+                if not line:
                     break
+                kid = line.split('\t', 2)[1].strip()
+                h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
+                h2 = f2.readline().rstrip()
                 f2.readline(); f2.readline(); f2.readline()
-                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
                 out.write(f"{kid}\\t{h1[1:]}\\t{h2[1:]}\\n")
     else:
         with open_file(reads[0]) as f1:
             while True:
-                h1 = f1.readline().rstrip()
-                if not h1:
+                line = kc.readline()
+                if not line:
                     break
+                kid = line.split('\t', 2)[1].strip()
+                h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
-                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
                 out.write(f"{kid}\\t{h1[1:]}\\n")
 PY
 

--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -39,7 +39,7 @@ with open_file(classification) as kc, open(output, 'w') as out:
                 line = kc.readline()
                 if not line:
                     break
-                kid = line.split('\t', 2)[1].strip()
+                kid = line.split('\\t', 2)[1].strip()
                 h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
                 h2 = f2.readline().rstrip()
@@ -51,7 +51,7 @@ with open_file(classification) as kc, open(output, 'w') as out:
                 line = kc.readline()
                 if not line:
                     break
-                kid = line.split('\t', 2)[1].strip()
+                kid = line.split('\\t', 2)[1].strip()
                 h1 = f1.readline().rstrip()
                 f1.readline(); f1.readline(); f1.readline()
                 out.write(f"{kid}\\t{h1[1:]}\\n")

--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -1,0 +1,59 @@
+process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "conda-forge::python=3.10.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.10.4' :
+        'biocontainers/python:3.10.4' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path('*kraken2.map.txt'), emit: mapping
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    python - ${reads} ${meta.id}.kraken2.map.txt <<'PY'
+import gzip, sys
+
+def open_file(p):
+    return gzip.open(p, 'rt') if p.endswith('.gz') else open(p, 'r')
+
+reads = sys.argv[1:-1]
+output = sys.argv[-1]
+
+with open(output, 'w') as out:
+    if len(reads) == 2:
+        with open_file(reads[0]) as f1, open_file(reads[1]) as f2:
+            while True:
+                h1 = f1.readline().rstrip()
+                h2 = f2.readline().rstrip()
+                if not h1 or not h2:
+                    break
+                f1.readline(); f1.readline(); f1.readline()
+                f2.readline(); f2.readline(); f2.readline()
+                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
+                out.write(f"{kid}\\t{h1[1:]}\\t{h2[1:]}\\n")
+    else:
+        with open_file(reads[0]) as f1:
+            while True:
+                h1 = f1.readline().rstrip()
+                if not h1:
+                    break
+                f1.readline(); f1.readline(); f1.readline()
+                kid = h1[1:].split()[0].replace('/1','').replace('/2','')
+                out.write(f"{kid}\\t{h1[1:]}\\n")
+PY
+
+cat <<-END_VERSIONS > versions.yml
+"${task.process}":
+    python: \$(python --version | sed 's/Python //g')
+END_VERSIONS
+    """
+}

--- a/modules/local/map_kraken2seqids_to_fqheaders.nf
+++ b/modules/local/map_kraken2seqids_to_fqheaders.nf
@@ -12,7 +12,7 @@ process MAP_KRAKEN2SEQIDS_TO_FQHEADERS {
 
     output:
     tuple val(meta), path('*kraken2.map.txt'), emit: mapping
-    path "versions.yml"                     , emit: versions
+    path "versions.yml"                      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,7 +30,6 @@ def open_file(p):
 reads = sys.argv[1:-2]
 classification = sys.argv[-2]
 output = sys.argv[-1]
-
 
 with open_file(classification) as kc, open(output, 'w') as out:
     if len(reads) == 2:

--- a/modules/nf-core/bbmap/filterbyname/environment.yml
+++ b/modules/nf-core/bbmap/filterbyname/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bbmap=39.18
+  - pigz=2.8

--- a/modules/nf-core/bbmap/filterbyname/main.nf
+++ b/modules/nf-core/bbmap/filterbyname/main.nf
@@ -1,0 +1,71 @@
+process BBMAP_FILTERBYNAME {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/5a/5aae5977ff9de3e01ff962dc495bfa23f4304c676446b5fdf2de5c7edfa2dc4e/data' :
+        'community.wave.seqera.io/library/bbmap_pigz:07416fe99b090fa9' }"
+
+    input:
+    tuple val(meta), path(reads)
+    val(names_to_filter)
+    val(output_format)
+    val(interleaved_output)
+
+    output:
+    tuple val(meta), path("*.${output_format}"), emit: reads
+    tuple val(meta), path('*.log')             , emit: log
+    path "versions.yml"                        , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def input  = meta.single_end ? "in=${reads}" : "in=${reads[0]} in2=${reads[1]}"
+    def output = (meta.single_end || interleaved_output) ?
+        "out=${prefix}.${output_format}" :
+        "out1=${prefix}_1.${output_format} out2=${prefix}_2.${output_format}"
+    def names_command = names_to_filter ? "names=${names_to_filter}": ""
+
+    def avail_mem = 3
+    if (!task.memory) {
+        log.info '[filterbyname] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = task.memory.giga
+    }
+
+    """
+    filterbyname.sh \\
+        -Xmx${avail_mem}g \\
+        $input \\
+        $output \\
+        $names_command \\
+        $args \\
+        | tee ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def filtered = (meta.single_end || interleaved_output) ?
+        "echo '' | gzip > ${prefix}.${output_format}" :
+        "echo '' | gzip >${prefix}_1.${output_format} ; echo '' | gzip >${prefix}_2.${output_format}"
+
+    """
+    $filtered
+    touch ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
+    """
+
+}

--- a/modules/nf-core/bbmap/filterbyname/meta.yml
+++ b/modules/nf-core/bbmap/filterbyname/meta.yml
@@ -1,0 +1,75 @@
+name: bbmap_filterbyname
+description: Filter out sequences by sequence header name(s)
+keywords:
+  - fastq
+  - fasta
+  - filter
+tools:
+  - bbmap:
+      description: BBMap is a short read aligner, as well as various other bioinformatic
+        tools.
+      homepage: https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/clumpify-guide/
+      documentation: https://www.biostars.org/p/225338/
+      licence: ["UC-LBL license (see package)"]
+      identifier: biotools:bbmap
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and
+          paired-end data, respectively.
+        ontologies: []
+  - names_to_filter:
+      type: string
+      description: |
+        String containing names of reads to filter out of the fastq files.
+  - output_format:
+      type: string
+      description: |
+        String with the format of the output file, e.g. fastq.gz, fasta, fasta.bz2
+  - interleaved_output:
+      type: boolean
+      description: |
+        Whether to produce an interleaved fastq output file
+output:
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.${output_format}":
+          type: file
+          description: The trimmed/modified fastq reads
+          pattern: "*${output_format}"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: filterbyname.sh log file
+          pattern: "*.filterbyname.log"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@tokarevvasily"
+  - "@sppearce"
+
+maintainers:
+  - "@sppearce"

--- a/modules/nf-core/bbmap/filterbyname/tests/main.nf.test
+++ b/modules/nf-core/bbmap/filterbyname/tests/main.nf.test
@@ -1,0 +1,218 @@
+nextflow_process {
+
+    name "Test Process BBMAP_FILTERBYNAME"
+    script "../main.nf"
+    process "BBMAP_FILTERBYNAME"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bbmap"
+    tag "bbmap/filterbyname"
+
+    test("paired end fastq.bz2") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = ""
+                input[2] = "fastq.bz2"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("paired end fastq.bz2 - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = ""
+                input[2] = "fastq.bz2"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("single end fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = ""
+                input[2] = "fasta"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("single end fasta - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = ""
+                input[2] = "fasta"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("single end fastq.gz filter") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
+                input[2] = "fasta"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("single end fastq.gz - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
+                input[2] = "fastq.gz"
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("paired end fastq.gz filter interleaved") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
+                input[2] = "fastq.gz"
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("paired end fastq.gz filter interleaved - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                 ]
+                input[1] = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
+                input[2] = "fastq.gz"
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bbmap/filterbyname/tests/main.nf.test.snap
+++ b/modules/nf-core/bbmap/filterbyname/tests/main.nf.test.snap
@@ -1,0 +1,145 @@
+{
+    "single end fasta": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:41:48.505978"
+    },
+    "paired end fastq.bz2": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:41:37.638626"
+    },
+    "paired end fastq.bz2 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastq.bz2:md5,1a60c330fb42841e8dcf3cd507a70bfc",
+                            "test_2.fastq.bz2:md5,1a60c330fb42841e8dcf3cd507a70bfc"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.fastq.bz2:md5,1a60c330fb42841e8dcf3cd507a70bfc",
+                            "test_2.fastq.bz2:md5,1a60c330fb42841e8dcf3cd507a70bfc"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:41:43.033923"
+    },
+    "single end fastq.gz filter": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:41:59.275477"
+    },
+    "single end fastq.gz - stub": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:42:03.939405"
+    },
+    "paired end fastq.gz filter interleaved - stub": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:42:15.868436"
+    },
+    "single end fasta - stub": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:41:53.798312"
+    },
+    "paired end fastq.gz filter interleaved": {
+        "content": [
+            [
+                "versions.yml:md5,6364bdef80e6301093cbaf97da6b8e6c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T18:42:10.101876"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params {
     skip_filter                             = false
     filter_trimmed                          = false
     output_removed_reads                    = false
+    filtering_tool                         = 'seqkit'
     classification_kraken2                  = false
     classification_bbduk                    = false
     validation_blastn                       = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -78,6 +78,12 @@
                     "description": "If the filtering step should be skipped.",
                     "help_text": "If set the filtering step is skipped and only assessing is performed."
                 },
+                "filtering_tool": {
+                    "type": "string",
+                    "default": "seqkit",
+                    "enum": ["seqkit", "bbmap"],
+                    "description": "Tool used for read filtering. Available options: 'seqkit' or 'bbmap'."
+                },
                 "output_removed_reads": {
                     "type": "boolean",
                     "description": "If the removed reads should also be written to the output folder."

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -82,7 +82,7 @@
                     "type": "string",
                     "default": "seqkit",
                     "enum": ["seqkit", "bbmap"],
-                    "description": "Tool used for read filtering. Available options: 'seqkit' or 'bbmap'."
+                    "description": "Select the read-filtering tool: seqkit or bbmap. seqkit normalizes FASTQ headers by temporarily renaming them; bbmap uses filterbyname.sh for exact header matching -- Note: BBTools I/O forces any base that is N to Q=0 (!)."
                 },
                 "output_removed_reads": {
                     "type": "boolean",

--- a/subworkflows/local/utils_nfcore_detaxizer_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_detaxizer_pipeline/main.nf
@@ -196,7 +196,7 @@ def toolCitationText() {
             params["classification_kraken2"] | !params["classification_bbduk"] & !params["classification_kraken2"] ? "Kraken2 (Wood et al. 2019)," : "",
             params["classification_bbduk"] ? "BBMap (Bushnell B. 2022)," : "",
             params["validation_blastn"] ? "BLAST (Altschul et al. 1990)," : "",
-            params["validation_blastn"] | !params["skip_filter"] | params["classification_bbduk"] ? "seqkit (Shen et al. 2016)," : "",
+            params["validation_blastn"] | (!params["skip_filter"] & params["filtering_tool"] == "seqkit") | params["classification_bbduk"] ? "seqkit (Shen et al. 2016)," : "",
             "MultiQC (Ewels et al. 2016)",
             "."
         ].join(' ').trim()

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -427,6 +427,8 @@ workflow NFCORE_DETAXIZER {
                 ch_filter_removed = BBMAP_FILTERBYNAME_REMOVED.out.reads
             } else {
                 ch_filter_removed = Channel.empty()
+            }
+        }
     //
     // MODULE: Rename headers after filtering
     //

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -19,7 +19,7 @@ include { KRAKEN2_KRAKEN2 as KRAKEN2_POST_CLASSIFICATION_REMOVED    } from '../m
 include { BBMAP_BBDUK                                               } from '../modules/nf-core/bbmap/bbduk/main'
 include { BLAST_BLASTN                                              } from '../modules/nf-core/blast/blastn/main'
 include { BLAST_MAKEBLASTDB                                         } from '../modules/nf-core/blast/makeblastdb/main'
-include { BBMAP_FILTERBYNAME                                       } from '../modules/nf-core/bbmap/filterbyname/main'
+include { BBMAP_FILTERBYNAME                                        } from '../modules/nf-core/bbmap/filterbyname/main'
 include { BBMAP_FILTERBYNAME as BBMAP_FILTERBYNAME_REMOVED          } from '../modules/nf-core/bbmap/filterbyname/main'
 
 include { RENAME_FASTQ_HEADERS_PRE                                  } from '../modules/local/rename_fastq_headers_pre'

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -414,13 +414,19 @@ workflow NFCORE_DETAXIZER {
             ch_filter_removed  = FILTER.out.removed
         } else {
             BBMAP_FILTERBYNAME(
-                ch_to_filter.map { meta, reads, ids -> [ meta, reads, ids.toString(), 'fastq.gz', false ] }
+                ch_to_filter.map { meta, reads, ids -> tuple(meta, reads) },
+                ch_to_filter.map { meta, reads, ids -> ids.toString() },
+                Channel.value('fastq.gz'),
+                Channel.value(false)
             )
             ch_versions = ch_versions.mix(BBMAP_FILTERBYNAME.out.versions.first())
             ch_filter_filtered = BBMAP_FILTERBYNAME.out.reads
             if ( params.output_removed_reads ) {
                 BBMAP_FILTERBYNAME_REMOVED(
-                    ch_to_filter.map { meta, reads, ids -> [ meta, reads, ids.toString(), 'fastq.gz', false ] },
+                    ch_to_filter.map { meta, reads, ids -> tuple(meta, reads) },
+                    ch_to_filter.map { meta, reads, ids -> ids.toString() },
+                    Channel.value('fastq.gz'),
+                    Channel.value(false),
                     task: [ ext: [ args: 'include=t' ] ]
                 )
                 ch_versions = ch_versions.mix(BBMAP_FILTERBYNAME_REMOVED.out.versions.first())

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -376,7 +376,7 @@ workflow NFCORE_DETAXIZER {
         ch_blastn_summary = ch_blastn_summary.summary.map {
                 meta, path -> [path]
             }
-        }
+    }
 
     //
     // MODULE: Filter out the classified or validated reads
@@ -429,6 +429,7 @@ workflow NFCORE_DETAXIZER {
                 ch_filter_removed = Channel.empty()
             }
         }
+    }
     //
     // MODULE: Rename headers after filtering
     //

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -426,8 +426,7 @@ workflow NFCORE_DETAXIZER {
                     ch_to_filter.map { meta, reads, ids -> tuple(meta, reads) },
                     ch_to_filter.map { meta, reads, ids -> ids.toString() },
                     Channel.value('fastq.gz'),
-                    Channel.value(false),
-                    task: [ ext: [ args: 'include=t' ] ]
+                    Channel.value(false)
                 )
                 ch_versions = ch_versions.mix(BBMAP_FILTERBYNAME_REMOVED.out.versions.first())
                 ch_filter_removed = BBMAP_FILTERBYNAME_REMOVED.out.reads

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -165,6 +165,8 @@ workflow NFCORE_DETAXIZER {
         if ( params.filtering_tool == 'bbmap' ) {
             MAP_KRAKEN2SEQIDS_TO_FQHEADERS(
                 ch_fastq_for_classification
+                    .join(KRAKEN2_KRAKEN2.out.classified_reads_assignment, by: 0)
+                    .map { meta, reads, classification -> [meta, reads, classification] }
             )
             ch_versions = ch_versions.mix(MAP_KRAKEN2SEQIDS_TO_FQHEADERS.out.versions.first())
         }

--- a/workflows/detaxizer.nf
+++ b/workflows/detaxizer.nf
@@ -201,7 +201,7 @@ workflow NFCORE_DETAXIZER {
 
         ch_versions = ch_versions.mix(ISOLATE_KRAKEN2_IDS.out.versions.first())
 
-    }
+        }
 
     if (params.classification_bbduk) {
 


### PR DESCRIPTION
<!--
# nf-core/detaxizer pull request

Many thanks for contributing to nf-core/detaxizer!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
-->

This PR adds bbmap/filterbyname.sh as an alternative read-filtering tool, selectable via the --filtering_tool parameter.

bbmap/filterbyname.sh natively handles paired-end reads, eliminating the need for FASTQ header renaming before and after filtering.
This results in a significant runtime improvement.

The default value for --filtering_tool remains seqkit to preserve the current workflow behavior.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/detaxizer/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/detaxizer _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
